### PR TITLE
Fixes dependencies

### DIFF
--- a/Telemachus/AfterBuild.bat
+++ b/Telemachus/AfterBuild.bat
@@ -1,0 +1,23 @@
+rd /s /q  "%1%..\publish\GameData"
+rd /s /q "%1%..\ksp-telemachus-dev\GameData\Telemachus"
+
+xcopy "%2%Servers.dll" "%1%..\publish\GameData\Telemachus\Plugins\" /e /y /i /r
+xcopy "%2%Telemachus.dll" "%1%..\publish\GameData\Telemachus\Plugins\" /e /y /i /r
+xcopy "%2%websocket-sharp.dll" "%1%..\publish\GameData\Telemachus\Plugins\" /e /y /i /r
+
+xcopy "%1%..\Parts\*" "%1%..\publish\GameData\Telemachus\Parts\"  /e /y /i /r
+xcopy "%1%..\WebPages\WebPages\src\*" "%1%..\publish\GameData\Telemachus\Plugins\PluginData\Telemachus\" /e /y /i /r
+xcopy "%1%..\licences\*" "%1%..\publish\GameData\Telemachus\" /e /y /i /r
+copy "%1%..\readme.md" "%1%..\publish\GameData\Telemachus\"
+
+xcopy "%1%..\WebPages\WebPagesTest\src\*" "%1%..\ksp-telemachus-dev\GameData\Telemachus\Plugins\PluginData\Telemachus\test" /e /y /i /r
+xcopy "%1%..\publish\GameData\*"  "%1%..\ksp-telemachus-dev\GameData\" /e /y /i /r
+powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $assets = Invoke-WebRequest -Uri https://api.github.com/repos/TeleIO/houston/releases/latest | ConvertFrom-Json; $assets = $assets.assets; iwr $assets.browser_download_url -OutFile h.zip; Expand-Archive -Path h.zip -DestinationPath houston;"
+
+
+mkdir "%1%..\publish\GameData\Telemachus\Plugins\PluginData\Telemachus\houston"
+xcopy "%2%houston\*" "%1%..\publish\GameData\Telemachus\Plugins\PluginData\Telemachus\houston"  /e /y /i /r
+powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iwr https://github.com/TeleIO/mkon/archive/master.zip -OutFile mkon.zip; Expand-Archive -Path mkon.zip -DestinationPath mkon;"      
+mkdir "%1%..\publish\GameData\Telemachus\Plugins\PluginData\Telemachus\mkon"
+xcopy "%2%mkon\mkon-master\*" "%1%..\publish\GameData\Telemachus\Plugins\PluginData\Telemachus\mkon"  /e /y /i /r
+dir "%1%..\publish\GameData\Telemachus\Plugins\PluginData\Telemachus\"

--- a/Telemachus/AfterBuild.sh
+++ b/Telemachus/AfterBuild.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+ProjectDir=$1
+TargetDir=$2
+houstonUrl="$(curl --silent "https://api.github.com/repos/TeleIO/houston/releases/latest" | grep '"browser_download_url":'  | cut -d : -f2,3 | cut -d \" -f2)"
+mkonUrl="https://github.com/TeleIO/mkon/archive/master.zip" 
+echo $ProjectDir
+echo $TargetDir
+
+rm -r  "$ProjectDir/../publish/GameData"
+rm -r "$ProjectDir/../ksp-telemachus-dev/GameData/Telemachus"
+
+mkdir -p  "$ProjectDir/../publish/GameData/Telemachus/Plugins"
+mkdir -p  "$ProjectDir/../publish/GameData/Telemachus/Parts"
+mkdir -p  "$ProjectDir/../publish/GameData/Telemachus/PluginData"
+mkdir -p "$ProjectDir/../ksp-telemachus-dev/GameData/Telemachus"
+mkdir -p "$ProjectDir/../ksp-telemachus-dev/GameData/Telemachus/Plugins/PluginData/Telemachus/test"
+mkdir -p "$ProjectDir/../publish/GameData/Telemachus/Plugins/PluginData/Telemachus/"
+
+#cp "$TargetDir/Servers.dll" "$ProjectDir/../publish/GameData/Telemachus/Plugins/"
+cp "$TargetDir/Telemachus.dll" "$ProjectDir/../publish/GameData/Telemachus/Plugins/"
+cp "$TargetDir/websocket-sharp.dll" "$ProjectDir/../publish/GameData/Telemachus/Plugins/"
+
+cp -ra "$ProjectDir/../Parts/." "$ProjectDir/../publish/GameData/Telemachus/Parts/" 
+cp -ra "$ProjectDir/../WebPages/WebPages/src/." "$ProjectDir/../publish/GameData/Telemachus/Plugins/PluginData/Telemachus/"
+cp -ra "$ProjectDir/../Licences/." "$ProjectDir/../publish/GameData/Telemachus/"
+cp "$ProjectDir/../readme.md" "$ProjectDir/../publish/GameData/Telemachus/"
+
+cp -ra "$ProjectDir/../WebPages/WebPagesTest/src/." "$ProjectDir/../ksp-telemachus-dev/GameData/Telemachus/Plugins/PluginData/Telemachus/test"
+cp -ra "$ProjectDir/../publish/GameData/."  "$ProjectDir/../ksp-telemachus-dev/GameData/"
+
+curl -LO $houstonUrl
+mkdir -p "$ProjectDir/../publish/GameData/Telemachus/Plugins/PluginData/Telemachus/houston"
+unzip Houston.zip -d "$ProjectDir/../publish/GameData/Telemachus/Plugins/PluginData/Telemachus/houston"
+
+curl -Lo mkon.zip $mkonUrl      
+mkdir -p "$ProjectDir/../publish/GameData/Telemachus/Plugins/PluginData/Telemachus/mkon"
+unzip mkon.zip
+cp -ra mkon-master/. "$ProjectDir/../publish/GameData/Telemachus/Plugins/PluginData/Telemachus/mkon"
+
+rm Houston.zip
+rm mkon.zip
+rm -r mkon-master
+ 
+
+ls "$ProjectDir/../publish/GameData/Telemachus/Plugins/PluginData/Telemachus/"

--- a/Telemachus/Telemachus.csproj
+++ b/Telemachus/Telemachus.csproj
@@ -39,6 +39,15 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\ksp-telemachus-dev\KSP_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.ImageConversionModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\ksp-telemachus-dev\KSP_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UnityWebRequestWWWModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\ksp-telemachus-dev\KSP_Data\Managed\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
+    </Reference>
     <Reference Include="websocket-sharp">
       <HintPath>..\websocket-sharp.dll</HintPath>
     </Reference>

--- a/Telemachus/Telemachus.csproj
+++ b/Telemachus/Telemachus.csproj
@@ -105,38 +105,17 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="AfterBuild.bat" />
+    <Content Include="AfterBuild.sh" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>rd /s /q  "$(ProjectDir)..\publish\GameData"
-rd /s /q "$(ProjectDir)..\ksp-telemachus-dev\GameData\Telemachus"
-
-xcopy "$(TargetDir)Servers.dll" "$(ProjectDir)..\publish\GameData\Telemachus\Plugins\" /e /y /i /r
-xcopy "$(TargetDir)Telemachus.dll" "$(ProjectDir)..\publish\GameData\Telemachus\Plugins\" /e /y /i /r
-xcopy "$(TargetDir)websocket-sharp.dll" "$(ProjectDir)..\publish\GameData\Telemachus\Plugins\" /e /y /i /r
-
-xcopy "$(ProjectDir)..\Parts\*" "$(ProjectDir)..\publish\GameData\Telemachus\Parts\"  /e /y /i /r
-xcopy "$(ProjectDir)..\WebPages\WebPages\src\*" "$(ProjectDir)..\publish\GameData\Telemachus\Plugins\PluginData\Telemachus\" /e /y /i /r
-xcopy "$(ProjectDir)..\licences\*" "$(ProjectDir)..\publish\GameData\Telemachus\" /e /y /i /r
-copy "$(ProjectDir)..\readme.md" "$(ProjectDir)..\publish\GameData\Telemachus\"
-
-xcopy "$(ProjectDir)..\WebPages\WebPagesTest\src\*" "$(ProjectDir)..\ksp-telemachus-dev\GameData\Telemachus\Plugins\PluginData\Telemachus\test" /e /y /i /r
-xcopy "$(ProjectDir)..\publish\GameData\*"  "$(ProjectDir)..\ksp-telemachus-dev\GameData\" /e /y /i /r
-powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $assets = Invoke-WebRequest -Uri https://api.github.com/repos/TeleIO/houston/releases/latest | ConvertFrom-Json; $assets = $assets.assets; iwr $assets.browser_download_url -OutFile h.zip; Expand-Archive -Path h.zip -DestinationPath houston;"
-
-
-mkdir "$(ProjectDir)..\publish\GameData\Telemachus\Plugins\PluginData\Telemachus\houston"
-xcopy "$(TargetDir)houston\*" "$(ProjectDir)..\publish\GameData\Telemachus\Plugins\PluginData\Telemachus\houston"  /e /y /i /r
-powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iwr https://github.com/TeleIO/mkon/archive/master.zip -OutFile mkon.zip; Expand-Archive -Path mkon.zip -DestinationPath mkon;"      
-mkdir "$(ProjectDir)..\publish\GameData\Telemachus\Plugins\PluginData\Telemachus\mkon"
-xcopy "$(TargetDir)mkon\mkon-master\*" "$(ProjectDir)..\publish\GameData\Telemachus\Plugins\PluginData\Telemachus\mkon"  /e /y /i /r
-dir "$(ProjectDir)..\publish\GameData\Telemachus\Plugins\PluginData\Telemachus\"
-    </PostBuildEvent>
-  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
-  </Target>
+  </Target>-->
   <Target Name="AfterBuild">
+    <Exec Command="./AfterBuild.sh $(ProjectDir) $(TargetDir)" Condition=" '$(OS)' != 'Windows_NT' " />
+    <Exec Command="AfterBuild.bat $(ProjectDir) $(TargetDir)" Condition=" '$(OS)' == 'Windows_NT' " />
   </Target>
-  -->
 </Project>

--- a/Telemachus/src/CameraSnapshots/CameraCapture.cs
+++ b/Telemachus/src/CameraSnapshots/CameraCapture.cs
@@ -219,7 +219,7 @@ namespace Telemachus.CameraSnapshots
                 "BG COLOR: " + camera.backgroundColor,
                 "CULLING MASK: " + camera.cullingMask,
                 "DEPTH: " + camera.depth,
-                "HDR: " + camera.hdr,
+                "HDR: " + camera.allowHDR,
                 "POSITION: " + camera.transform.position,
                 "ROT: " + camera.transform.rotation,
                 "NEAR: " + camera.nearClipPlane,


### PR DESCRIPTION
Hi,

I just needed the plugin to work with KSP1.8 so I made a few changes:
* adds missing dependecies
* uses camera.allowHDR in CamerCapture.cs instead of camera.hdr as it was the closes matching property
* splits post-build steps into os dependent scripts

Regarding the change in CameraCapture.cs I'm not quite sure whether or not it is correct. However the plugin did not compile because camera.hdr was unknown.

The post-build script worked under linux und my machine (arch linux) and makes only use of very basic commands. There should no need to install extra tools on most linux systems. However, someone should have a look on the AfterBuild.bat and make sure it works. I was not able to test it.

What I tested:
Small spacecraft with Telemachus fin and access the webserver to check telemetry.

I case there are any questions I'm more then happy to answer them.