### PR TITLE
Hardened the post-build script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ ksp-telemachus-dev
 Telemachus.v12.suo
 WebPages/WebPages.v12.suo
 *.ide-wal
+.vs/Telemachus/xs
 .vs/Telemachus/v15/.suo
 .vs/Telemachus/v15/Server/sqlite3/db.lock
 .vs/Telemachus/v15/Server/sqlite3/storage.ide

--- a/Telemachus/AfterBuild.sh
+++ b/Telemachus/AfterBuild.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
 ProjectDir=$1
 TargetDir=$2
 houstonUrl="$(curl --silent "https://api.github.com/repos/TeleIO/houston/releases/latest" | grep '"browser_download_url":'  | cut -d : -f2,3 | cut -d \" -f2)"

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,7 @@ Current status of project:
 * click Build->Build Solution and wait
 * the actual telemachus build artefacts will be copied to `$YOURGITREPO/Telemachus/bin/Debug` / `$YOURGITREPO/Telemachus/bin/Release`  by visual studio
 * The AfterBuild.(bat/sh) script will copy together all kinds of files(build artefacts+external deps (MKON,houston), telemachus DLLs + parts etc) into `$YOURGITREPO/publish`.
+  * Make sure to provide the project directory (the directory `AfterBuild.sh` lives in and the target directory (e.g. `bin/debug`) as the first and second argument, respectively (e.g. `./AfterBuild.sh . bin/debug` if running from the directory `AfterBuild.sh` lives in).
   * for mkon&houston: mkon & houston releases are simply downloaded from github,extracted and copied into the right place under `$YOURGITREPO/publish/GameData/Telemachus/Plugins/PluginData/Telemachus/...` 
 
 * to test a build copy the complete folder `Telemachus` found under `$YOURGITREPO/publish/GameData/` into your KSP install under `$KSPinstall/GameData/` and start ksp. you maybe want to delete a preexisting `Telemachus` folder in your `$KSPinstall/GameData`.


### PR DESCRIPTION
* Previously the post-build did not handle it if one did not pass any
  arguments (i.e. the project and target directory). This causes the
  variables to be empty and thus causes the script to work directly
  on the filesystem root (`/`), which is dangerous.
* I added `set -o nounset` to ensure no variables that are unset are
  able to be used.
* Besides that, I added information about those two parameters to the
  readme file.