### PR TITLE
Closes TeleIO/Telemachus-1#6

### DIFF
--- a/Telemachus/Telemachus.csproj
+++ b/Telemachus/Telemachus.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Telemachus</RootNamespace>
     <AssemblyName>Telemachus</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -22,7 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>4</LangVersion>
+    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -32,7 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>4</LangVersion>
+    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>

--- a/Telemachus/src/DataLinkHandlers.cs
+++ b/Telemachus/src/DataLinkHandlers.cs
@@ -2057,7 +2057,7 @@ namespace Telemachus
 
         public List<T> get(DataSources dataSources)
         {
-            string ID = dataSources.args[0].ToLowerInvariant();
+            string ID = dataSources.args[0];
             List<T> avail = null, ret = null;
 
             lock (cacheLock)


### PR DESCRIPTION
Fixes sensors not reporting data and moves the C# compiler version to 6.0 to take advantage of string interpolation.