### PR TITLE
Limit zoom on map

### DIFF
--- a/WebPages/WebPages/src/map.html
+++ b/WebPages/WebPages/src/map.html
@@ -31,6 +31,7 @@
             const map = new L.map('map', {
                 crs: L.CRS.EPSG4326,
                 zoom: 0,
+                maxZoom: 7,
                 center: [-0.1027, -74.5754],
                 bodyControl: false,
                 layerControl: true,


### PR DESCRIPTION
Limit the zoom on the map to zoomlevel 7, which is the max zoom level provided by KerbalMaps.
Zooming in further results in 404 errors on the map tiles