### PR TITLE
Update version file URL property

### DIFF
--- a/TelemachusReborn.version
+++ b/TelemachusReborn.version
@@ -1,6 +1,6 @@
 {
   "NAME": "Telemachus Reborn",
-  "URL": "https://raw.githubusercontent.com/TeleIO/Telemachus-1/master/TelemachusReborn.version",
+  "URL": "https://raw.githubusercontent.com/TeleIO/Telemachus-1/main/TelemachusReborn.version",
   "DOWNLOAD": "https://github.com/TeleIO/Telemachus-1/releases/latest",
   "GITHUB": {
     "USERNAME": "TeleIO",


### PR DESCRIPTION
Hi!

The version file has `master` where the current branch is actually `main`, so the URL is a 404 when accessed via the GitHub API (the auto redirect is implemented only for the Web UI).
This PR fixes it.

Noticed while working on KSP-CKAN/NetKAN#10977.

Cheers!
