### PR TITLE
Fix/fix http connection

### DIFF
--- a/Telemachus/Telemachus.csproj
+++ b/Telemachus/Telemachus.csproj
@@ -5,8 +5,8 @@
     <LangVersion>12</LangVersion>
     <AssemblyName>Telemachus</AssemblyName>
     <RootNamespace>Telemachus</RootNamespace>
-    <AssemblyVersion>1.10.0</AssemblyVersion>
-    <FileVersion>1.10.0</FileVersion>
+    <AssemblyVersion>1.10.1</AssemblyVersion>
+    <FileVersion>1.10.1</FileVersion>
 
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/Telemachus/src/KSPWebServerDispatcher.cs
+++ b/Telemachus/src/KSPWebServerDispatcher.cs
@@ -19,6 +19,8 @@ namespace Telemachus
         /// Iterate over all responders to find one that works
         public void DispatchRequest(object sender, HttpRequestEventArgs request)
         {
+            ApplyConnectionPolicy(request.Request, request.Response);
+
             foreach (var responder in responderChain.Reverse<IHTTPRequestResponder>())
             {
                 try
@@ -40,6 +42,17 @@ namespace Telemachus
         public void AddResponder(IHTTPRequestResponder responder)
         {
             responderChain.Add(responder);
+        }
+
+        private static void ApplyConnectionPolicy(HttpListenerRequest request, HttpListenerResponse response)
+        {
+            var connectionHeader = request.Headers["Connection"];
+            if (connectionHeader == null) return;
+
+            if (connectionHeader.IndexOf("close", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                response.KeepAlive = false;
+            }
         }
     }
 }

--- a/TelemachusReborn.version
+++ b/TelemachusReborn.version
@@ -10,7 +10,7 @@
   "VERSION": {
     "MAJOR": 1,
     "MINOR": 10,
-    "PATCH": 0,
+    "PATCH": 1,
     "BUILD": 0
   },
   "KSP_VERSION": {


### PR DESCRIPTION
Honor Connection: close on HTTP/1.1 responses

Telemachus uses websocket-sharp's HttpServer, where the bundled
HttpListenerRequest.KeepAlive logic treats HTTP/1.1 as keep-alive by
default and does not honor Connection: close.

Since Telemachus did not explicitly disable keep-alive on
HttpListenerResponse, responses were sent as persistent even when the
client requested connection close.

Set response.KeepAlive = false when the incoming Connection header
contains close.

Fixes #78 