### PR TITLE
fix: auto-defer attribute-based action handlers to main thread

### DIFF
--- a/Telemachus/src/DataLinkHandlerBase.cs
+++ b/Telemachus/src/DataLinkHandlerBase.cs
@@ -76,7 +76,8 @@ namespace Telemachus
 
                 APIEntry entry;
                 if (attr.IsAction)
-                    entry = new ActionAPIEntry(fn, attr.Key, attr.Description, formatter);
+                    // Action handlers must run on the main Unity thread
+                    entry = new ActionAPIEntry(queueDelayed(fn), attr.Key, attr.Description, formatter);
                 else if (attr.Plotable)
                     entry = new PlotableAPIEntry(fn, attr.Key, attr.Description,
                         formatter, attr.Units, attr.AlwaysEvaluable);


### PR DESCRIPTION
⚠️ I've used Claude to debug and make this change, and write most of the description below. I've got the change built and working locally and I'm happy with the changes, so sharing here.

## Summary

Wraps every action handler registered via `[TelemetryAPI(IsAction = true)]` in `queueDelayed(...)` so it runs on the main Unity thread instead of the WebSocketSharp HTTP worker thread. Systemic counterpart to e95d3d2.

Refs #73.

## Reproduction

Calling `tar.setTargetBody[<index>]` or `tar.clearTarget` consistently crashes KSP with SIGSEGV. Player.log shows:

```
#23 Telemachus.DataLinkResponsibility:process       <- worker thread
#22 ScreenMessages:PostScreenMessage                <- KSP toast
#20 UnityEngine.Object:Internal_CloneSingle
#3  Mesh::AwakeFromLoad
#1  Mesh::CreateMesh
#0  __sigaction                                     <- SIGSEGV
```

`KSPWebServerDispatcher` lives in WebSocketSharp's HTTP server, which dispatches request handling on a worker thread. `FlightGlobals.fetch.SetVesselTarget(...)` triggers KSP's "Target: ..." on-screen toast, the toast clones a Mesh GameObject, and Unity SIGSEGVs because Mesh allocation must happen on the main thread.

## Root cause

Constructor-style action registrations (e.g. `TimeWarpDataLinkHandler`) already wrap their delegates in `queueDelayed(...)` so the action runs from `TelemachusBehaviour.Update()` (main thread). The newer attribute-based registration path in `RegisterAnnotatedMethods` bypasses that wrapping, so `[TelemetryAPI(IsAction = true)]` handlers are called directly from the worker thread.

Commit e95d3d2 fixed the same threading bug for `m.toggleMapView` / `m.enterMapView` / `m.exitMapView` by moving them out of the attribute system back to constructor-style registration. That fix works but is per-handler: every new attribute-registered action that touches Unity is a future crash waiting to happen.

## Fix

One-line change in `DataLinkHandlerBase.RegisterAnnotatedMethods`: when `attr.IsAction` is true, wrap the delegate in `queueDelayed` before constructing the `ActionAPIEntry`. Same wrap that constructor-style registrations use.

## Justification for wrapping all actions

Some attribute-registered actions do not touch Unity UI today (for example, `v.setPitch` writes a float into the flight-input callback with no mesh allocation), so they would not crash even from the worker thread. The blanket wrap is deliberate to ensure that any future action won't need the same fixes as previous ones. Full justification:

1. **Future-proof.** Any handler that later acquires a Unity UI side effect (a screen message, an indicator update, an animation trigger) silently reintroduces the same bug. Per-handler wrapping requires every future contributor to remember the rule.
2. **Consistency.** Constructor-style registrations always wrap. Treating attribute-based the same way removes a footgun where two registration paths have different threading contracts.
3. **Negligible cost.** One Unity frame of latency, around 17 ms at 60 fps. Imperceptible for human-driven actions and well below WS readback cadence.
4. **Failure mode is uniform.** Existing constructor-style actions already cannot assume a synchronous return value over HTTP; making the attribute path identical removes a class of latent surprise rather than introducing one.

## Validation

Tested locally on KSP 1.12.x with a custom HTTP/WS dashboard:

- `tar.setTargetBody[<index>]`: was crashing, now works (`tar.name` flips on the next Unity frame after the HTTP request returns).
- `tar.clearTarget`: was crashing, now works.
- `m.toggleMapView`: already fixed by e95d3d2, still works.

The same Player.log no longer shows the `KSPWebServerDispatcher -> Mesh::CreateMesh -> SIGSEGV` chain; the action runs from `TelemachusBehaviour.Update` instead.

## Notes

- HTTP responses for actions now return `false` (the `queueDelayed` placeholder), matching the contract that constructor-style queueDelayed actions have always had. Synchronous return values from the wrapped handlers are no longer surfaced over HTTP. The WS readback (`tar.name`, etc.) remains the source of truth for "did the action take effect".
- The per-handler workaround in `MapViewDataLinkHandler` (commit e95d3d2) becomes redundant with this change. Left in place here for minimum diff; it can be reverted to attribute-style in a follow-up.