### PR TITLE
feat: CORS allowlist for cross-origin HTTP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ All mod integrations are soft dependencies via reflection — no mod DLLs are re
 
 > The default port is **8085** and binds to `0.0.0.0` (all interfaces). Both can be changed in the plugin configuration file.
 
+### Cross-origin access (CORS)
+
+By default Telemachus sends no CORS headers, so browsers will block any JavaScript on a different origin (a different host, port, or scheme) from reading the responses. That covers the bundled web UI fine — it's served from the same origin as the API — but a dashboard hosted elsewhere (another machine on the LAN, a deployed static site, a dev server on a different port) needs an explicit opt-in.
+
+List the origins permitted to read cross-origin in `ALLOWED_ORIGINS` in `PluginData/Telemachus/config.xml`:
+
+```xml
+<string name="ALLOWED_ORIGINS">http://&lt;client-host&gt;:&lt;port&gt;,https://&lt;deployed-dashboard&gt;</string>
+```
+
+Comma-separated `scheme://host[:port]` entries — match exactly what the browser sends in the `Origin` header. Trailing slashes and empty entries are stripped. Empty list (the default) preserves the historical behaviour of never sending CORS headers, so existing setups are untouched.
+
+When a matching `Origin` arrives, Telemachus echoes it back in `Access-Control-Allow-Origin` (with `Vary: Origin`) rather than wildcarding, and responds 204 to the standard OPTIONS preflight. Non-allowlisted origins get no CORS header and the browser blocks the response by default.
+
 ---
 
 ## API overview

--- a/Telemachus/src/DataLinkResponsibility.cs
+++ b/Telemachus/src/DataLinkResponsibility.cs
@@ -72,28 +72,35 @@ namespace Telemachus
             return Json.DecodeObject(jsonBody);
         }
 
-        // Echoes the request Origin in Access-Control-Allow-Origin when it matches AllowedOrigins.
+        private bool corsConfigured =>
+            serverConfig != null && serverConfig.AllowedOrigins != null && serverConfig.AllowedOrigins.Count > 0;
+
+        // Whenever CORS is configured the response depends on Origin — emit Vary even on non-matches
+        // so shared caches don't serve a no-CORS response to a request that would have matched.
         private void applyCorsHeader(HttpListenerRequest request, HttpListenerResponse response)
         {
-            if (serverConfig == null || serverConfig.AllowedOrigins == null) return;
-            if (serverConfig.AllowedOrigins.Count == 0) return;
+            if (!corsConfigured) return;
+            response.Headers["Vary"] = "Origin";
+
             string origin = request.Headers["Origin"];
             if (string.IsNullOrEmpty(origin)) return;
+            // Defence in depth: reject any Origin containing CR/LF before echoing it into a header.
+            if (origin.IndexOfAny(new[] { '\r', '\n' }) >= 0) return;
             string normalised = origin.TrimEnd('/');
             if (!serverConfig.AllowedOrigins.Contains(normalised)) return;
             response.Headers["Access-Control-Allow-Origin"] = normalised;
-            response.Headers["Vary"] = "Origin";
         }
 
         public bool process(HttpListenerRequest request, HttpListenerResponse response)
         {
             if (!request.RawUrl.StartsWith(PAGE_PREFIX)) return false;
 
-            // CORS preflight: 204 with the standard headers if Origin is allowlisted.
-            if (string.Equals(request.HttpMethod, "OPTIONS", StringComparison.OrdinalIgnoreCase)
-                && serverConfig != null
-                && serverConfig.AllowedOrigins != null
-                && serverConfig.AllowedOrigins.Count > 0)
+            // CORS preflight: when CORS is configured, OPTIONS never goes through the data pipeline.
+            // 204 with preflight headers if the Origin is allowlisted; 204 without headers otherwise,
+            // rather than serialising an empty JSON body. When CORS is not configured we leave OPTIONS
+            // behaviour unchanged from before this PR (falls through to the data pipeline below).
+            if (corsConfigured
+                && string.Equals(request.HttpMethod, "OPTIONS", StringComparison.OrdinalIgnoreCase))
             {
                 applyCorsHeader(request, response);
                 if (response.Headers["Access-Control-Allow-Origin"] != null)
@@ -101,9 +108,9 @@ namespace Telemachus
                     response.Headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS";
                     response.Headers["Access-Control-Allow-Headers"] = "Content-Type";
                     response.Headers["Access-Control-Max-Age"] = "86400";
-                    response.StatusCode = 204;
-                    return true;
                 }
+                response.StatusCode = 204;
+                return true;
             }
 
             applyCorsHeader(request, response);

--- a/Telemachus/src/DataLinkResponsibility.cs
+++ b/Telemachus/src/DataLinkResponsibility.cs
@@ -19,12 +19,16 @@ namespace Telemachus
 
         private UpLinkDownLinkRate dataRates = null;
 
+        /// Optional; CORS headers aren't emitted when null
+        private readonly ServerConfiguration serverConfig;
+
         #region Initialisation
 
-        public DataLinkResponsibility(KSPAPIBase kspAPI, UpLinkDownLinkRate rateTracker)
+        public DataLinkResponsibility(KSPAPIBase kspAPI, UpLinkDownLinkRate rateTracker, ServerConfiguration serverConfig = null)
         {
             this.kspAPI = kspAPI;
             dataRates = rateTracker;
+            this.serverConfig = serverConfig;
         }
 
         #endregion
@@ -68,9 +72,41 @@ namespace Telemachus
             return Json.DecodeObject(jsonBody);
         }
 
+        // Echoes the request Origin in Access-Control-Allow-Origin when it matches AllowedOrigins.
+        private void applyCorsHeader(HttpListenerRequest request, HttpListenerResponse response)
+        {
+            if (serverConfig == null || serverConfig.AllowedOrigins == null) return;
+            if (serverConfig.AllowedOrigins.Count == 0) return;
+            string origin = request.Headers["Origin"];
+            if (string.IsNullOrEmpty(origin)) return;
+            string normalised = origin.TrimEnd('/');
+            if (!serverConfig.AllowedOrigins.Contains(normalised)) return;
+            response.Headers["Access-Control-Allow-Origin"] = normalised;
+            response.Headers["Vary"] = "Origin";
+        }
+
         public bool process(HttpListenerRequest request, HttpListenerResponse response)
         {
             if (!request.RawUrl.StartsWith(PAGE_PREFIX)) return false;
+
+            // CORS preflight: 204 with the standard headers if Origin is allowlisted.
+            if (string.Equals(request.HttpMethod, "OPTIONS", StringComparison.OrdinalIgnoreCase)
+                && serverConfig != null
+                && serverConfig.AllowedOrigins != null
+                && serverConfig.AllowedOrigins.Count > 0)
+            {
+                applyCorsHeader(request, response);
+                if (response.Headers["Access-Control-Allow-Origin"] != null)
+                {
+                    response.Headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS";
+                    response.Headers["Access-Control-Allow-Headers"] = "Content-Type";
+                    response.Headers["Access-Control-Max-Age"] = "86400";
+                    response.StatusCode = 204;
+                    return true;
+                }
+            }
+
+            applyCorsHeader(request, response);
 
             // Work out how big this request was
             long byteCount = request.RawUrl.Length + request.ContentLength64;

--- a/Telemachus/src/ServerConfiguration.cs
+++ b/Telemachus/src/ServerConfiguration.cs
@@ -17,6 +17,8 @@ namespace Telemachus
         public IPAddress ipAddress { get; set; } = IPAddress.Any;
         /// <summary>A list of IP Addresses that the server should be accessible at</summary>
         public List<IPAddress> ValidIpAddresses { get; set; } = new();
+        /// <summary>Browser origins permitted to read responses cross-origin. Empty = no CORS headers sent.</summary>
+        public List<string> AllowedOrigins { get; set; } = new();
     }
 
     internal static class ServerConfigExtensions

--- a/Telemachus/src/ServerConfiguration.cs
+++ b/Telemachus/src/ServerConfiguration.cs
@@ -17,8 +17,9 @@ namespace Telemachus
         public IPAddress ipAddress { get; set; } = IPAddress.Any;
         /// <summary>A list of IP Addresses that the server should be accessible at</summary>
         public List<IPAddress> ValidIpAddresses { get; set; } = new();
-        /// <summary>Browser origins permitted to read responses cross-origin. Empty = no CORS headers sent.</summary>
-        public List<string> AllowedOrigins { get; set; } = new();
+        /// <summary>Browser origins permitted to read responses cross-origin. Empty = no CORS headers sent.
+        /// Case-insensitive — RFC 6454 §6.1 says scheme and host are case-insensitive.</summary>
+        public HashSet<string> AllowedOrigins { get; set; } = new(StringComparer.OrdinalIgnoreCase);
     }
 
     internal static class ServerConfigExtensions

--- a/Telemachus/src/TelemachusBehaviour.cs
+++ b/Telemachus/src/TelemachusBehaviour.cs
@@ -69,7 +69,7 @@ namespace Telemachus
                     webDispatcher.AddResponder(new IOPageResponsibility());
                     var cameraLink = new CameraResponsibility(apiInstance, rateTracker);
                     webDispatcher.AddResponder(cameraLink);
-                    var dataLink = new DataLinkResponsibility(apiInstance, rateTracker);
+                    var dataLink = new DataLinkResponsibility(apiInstance, rateTracker, serverConfig);
                     webDispatcher.AddResponder(dataLink);
                     var apiRoute = new APIRouteResponsibility(apiInstance, rateTracker);
                     webDispatcher.AddResponder(apiRoute);
@@ -187,6 +187,18 @@ namespace Telemachus
 
             isPartless = config.GetValue<int>("PARTLESS") != 0;
             PluginLogger.print("Partless:" + isPartless);
+
+            // Comma-separated browser origins permitted to read responses cross-origin.
+            string originsRaw = config.GetValue<string>("ALLOWED_ORIGINS");
+            if (!string.IsNullOrEmpty(originsRaw))
+            {
+                foreach (var part in originsRaw.Split(','))
+                {
+                    var trimmed = part.Trim().TrimEnd('/');
+                    if (trimmed.Length > 0) serverConfig.AllowedOrigins.Add(trimmed);
+                }
+                PluginLogger.print("Allowed CORS origins: " + string.Join(", ", serverConfig.AllowedOrigins));
+            }
         }
 
         static private void stopDataLink()


### PR DESCRIPTION
⚠️ I've used Claude to make this change and draft most of the description below. Built, tested locally in KSP, and happy with the result, so sharing here.

## Summary

Adds a configurable CORS allowlist so JavaScript on origins other than the API host can read Telemachus responses. Today Telemachus sends no CORS headers at all, so anything hosted off-origin (a separate machine on the LAN, a deployed static dashboard, a dev server on a different port) is blocked by the browser even when the user explicitly wants it to work.

## Behaviour

- New `ALLOWED_ORIGINS` setting in `PluginConfiguration` (Telemachus's `PluginData/Telemachus/config.xml`).
- **Empty list (the default)** preserves the historical behaviour of never sending CORS headers — existing setups, including the bundled same-origin web UI, are unaffected.
- When configured:
  - Echoes the request's `Origin` in `Access-Control-Allow-Origin` if it matches the allowlist, with `Vary: Origin`. Echoing rather than emitting `*` keeps the same permissiveness for configured clients but blocks credentialed requests from arbitrary origins.
  - Responds 204 to OPTIONS preflight with standard `Access-Control-Allow-Methods` / `Access-Control-Allow-Headers` / `Access-Control-Max-Age`.
  - Non-allowlisted requests get no CORS header, so browsers block-by-default.

## Config example

```xml
<string name="ALLOWED_ORIGINS">http://&lt;client-host&gt;:&lt;port&gt;,https://&lt;deployed-dashboard&gt;</string>
```

Comma-separated `scheme://host[:port]` entries — match exactly what the browser sends in the `Origin` header. Trailing slashes and empty entries are stripped.

## Validation

Tested locally on KSP 1.12.x with `ALLOWED_ORIGINS` set in `config.xml`:

- `Allowed CORS origins: <list>` appears in `KSP.log` on init when the config is set.
- `curl -H "Origin: <allowlisted>" -i http://127.0.0.1:8085/telemachus/datalink?a=v.altitude` returns `Access-Control-Allow-Origin: <allowlisted>` + `Vary: Origin`.
- Same request from a non-allowlisted `Origin` returns no CORS header, and a browser fetch from that origin is blocked as expected.
- OPTIONS preflight with an allowlisted `Origin` returns 204 with the expected `Access-Control-*` headers.
- With `ALLOWED_ORIGINS` unset (the default), responses include no CORS headers at all — the bundled same-origin web UI continues to load normally.
