### PR TITLE
feat: alarm.add / alarm.delete and surface id in alarm rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,9 +698,13 @@ Example: `r.resource[ElectricCharge]`, `r.resource[LiquidFuel]`, `r.resource[Oxi
 | Key | Description |
 |-----|-------------|
 | `alarm.count` | Number of active alarms |
-| `alarm.list` | All alarms (complex object) |
+| `alarm.list` | All alarms (rows include `id`) |
 | `alarm.nextAlarm` | Next alarm to trigger |
 | `alarm.timeToNext` | Time until next alarm (s) |
+| `alarm.add[title, ut, warpAction?, message?]` | **Action:** create a stock-clock alarm; returns the new uint `id` |
+| `alarm.delete[id]` | **Action:** remove an alarm by id; returns `true` if it existed |
+
+`warpAction` ∈ `DoNothing | KillWarp | PauseGame` (default `KillWarp`). `message` ∈ `No | Yes | YesIfOtherVessel` (default `Yes`).
 
 ### `m.*` — Map view
 

--- a/Telemachus/src/AlarmClockHandlers.cs
+++ b/Telemachus/src/AlarmClockHandlers.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using UnityEngine;
 
 namespace Telemachus
 {
@@ -9,14 +10,14 @@ namespace Telemachus
         public AlarmClockDataLinkHandler(FormatterProvider formatters)
             : base(formatters) { }
 
-        [TelemetryAPI("alarm.count", "Number of Active Alarms", Category = "alarm", ReturnType = "int")]
+        [TelemetryAPI("alarm.count", "Number of Active Alarms", AlwaysEvaluable = true, Category = "alarm", ReturnType = "int")]
         object Count(DataSources ds)
         {
             var scenario = AlarmClockScenario.Instance;
             return scenario?.alarms?.Count ?? 0;
         }
 
-        [TelemetryAPI("alarm.list", "All Alarms", Plotable = false, Formatter = "AlarmList", Category = "alarm", ReturnType = "object")]
+        [TelemetryAPI("alarm.list", "All Alarms", AlwaysEvaluable = true, Plotable = false, Formatter = "AlarmList", Category = "alarm", ReturnType = "object")]
         object AlarmList(DataSources ds)
         {
             var scenario = AlarmClockScenario.Instance;
@@ -24,7 +25,7 @@ namespace Telemachus
             return scenario.alarms.Values.ToList();
         }
 
-        [TelemetryAPI("alarm.nextAlarm", "Next Alarm to Trigger", Plotable = false, Formatter = "Alarm", Category = "alarm", ReturnType = "object")]
+        [TelemetryAPI("alarm.nextAlarm", "Next Alarm to Trigger", AlwaysEvaluable = true, Plotable = false, Formatter = "Alarm", Category = "alarm", ReturnType = "object")]
         object NextAlarm(DataSources ds)
         {
             var scenario = AlarmClockScenario.Instance;
@@ -44,7 +45,7 @@ namespace Telemachus
             return nearest;
         }
 
-        [TelemetryAPI("alarm.timeToNext", "Time Until Next Alarm", Units = APIEntry.UnitType.TIME, Category = "alarm", ReturnType = "double")]
+        [TelemetryAPI("alarm.timeToNext", "Time Until Next Alarm", AlwaysEvaluable = true, Units = APIEntry.UnitType.TIME, Category = "alarm", ReturnType = "double")]
         object TimeToNext(DataSources ds)
         {
             var scenario = AlarmClockScenario.Instance;
@@ -58,6 +59,92 @@ namespace Telemachus
                     nearestTime = timeToAlarm;
             }
             return nearestTime < double.MaxValue ? nearestTime : -1;
+        }
+
+        // Manual main-thread queue (not IsAction) so the new alarm id returns sync.
+        [TelemetryAPI("alarm.add",
+            "Create a stock-clock alarm. Args: title, ut, [warpAction], [message]. " +
+            "warpAction = DoNothing | KillWarp | PauseGame (default KillWarp). " +
+            "message = No | Yes | YesIfOtherVessel (default Yes). " +
+            "Returns the new alarm's id (uint), or an error string.",
+            AlwaysEvaluable = true,
+            Category = "alarm",
+            ReturnType = "object",
+            Params = "string title, double ut, string warpAction, string message")]
+        object Add(DataSources ds)
+        {
+            var args = ds.args;
+            if (args == null || args.Count < 2)
+                return "expected [title, ut, warpAction?, message?]";
+
+            var title = args[0] ?? string.Empty;
+            if (!double.TryParse(args[1], out var ut))
+                return "ut not a number";
+
+            var warpName = args.Count >= 3 ? args[2] : "KillWarp";
+            var messageName = args.Count >= 4 ? args[3] : "Yes";
+
+            if (!Enum.TryParse<AlarmActions.WarpEnum>(warpName, true, out var warp))
+                return "warpAction must be DoNothing | KillWarp | PauseGame";
+            if (!Enum.TryParse<AlarmActions.MessageEnum>(messageName, true, out var msg))
+                return "message must be No | Yes | YesIfOtherVessel";
+
+            var scenario = AlarmClockScenario.Instance;
+            if (scenario == null) return "AlarmClock scenario not loaded";
+
+            // Ctor assigns alarm.Id sync via GetUniqueAlarmID.
+            var alarm = new AlarmTypeRaw
+            {
+                title = string.IsNullOrEmpty(title) ? "Telemachus Alarm" : title,
+                ut = ut,
+                actions =
+                {
+                    warp = warp,
+                    message = msg,
+                },
+            };
+            QueueOnMainThread(ds, _ =>
+            {
+                AlarmClockScenario.AddAlarm(alarm);
+                return null;
+            });
+            return alarm.Id;
+        }
+
+        [TelemetryAPI("alarm.delete",
+            "Remove a stock-clock alarm by id. Args: id. Returns true if " +
+            "the alarm was found and queued for removal, false if no alarm " +
+            "with that id exists right now.",
+            AlwaysEvaluable = true,
+            Category = "alarm",
+            ReturnType = "bool",
+            Params = "uint id")]
+        object Delete(DataSources ds)
+        {
+            var args = ds.args;
+            if (args == null || args.Count == 0) return "expected [id]";
+            if (!uint.TryParse(args[0], out var id)) return "id not a uint";
+
+            var scenario = AlarmClockScenario.Instance;
+            if (scenario?.alarms == null) return false;
+            if (!scenario.alarms.ContainsKey(id)) return false;
+
+            QueueOnMainThread(ds, _ =>
+            {
+                AlarmClockScenario.DeleteAlarm(id);
+                return null;
+            });
+            return true;
+        }
+
+        // Like queueDelayed but lets the caller return its own value sync.
+        private static void QueueOnMainThread(DataSources ds, DataLinkHandler.APIDelegate action)
+        {
+            var entry = new DelayedAPIEntry(ds.Clone(), action);
+            TelemachusBehaviour.instance.BroadcastMessage(
+                "queueDelayedAPI",
+                entry,
+                SendMessageOptions.DontRequireReceiver);
         }
     }
 }

--- a/Telemachus/src/DataLinkFormatters.cs
+++ b/Telemachus/src/DataLinkFormatters.cs
@@ -485,6 +485,7 @@ namespace Telemachus
             {
                 if (input is not AlarmTypeBase alarm) return null;
                 var d = new Dictionary<string, object>();
+                d["id"] = alarm.Id;
                 d["title"] = alarm.title;
                 d["description"] = alarm.description;
                 d["ut"] = alarm.ut;

--- a/docs/api-schema.json
+++ b/docs/api-schema.json
@@ -39,8 +39,7 @@
     "alwaysEvaluable": true,
     "category": "system",
     "returnType": "object",
-    "declaringClass": "APIDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/SystemHandlers.cs"
+    "declaringClass": "APIDataLinkHandler"
   },
   {
     "key": "a.physicsMode",
@@ -51,8 +50,7 @@
     "alwaysEvaluable": true,
     "category": "system",
     "returnType": "string",
-    "declaringClass": "APIDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/SystemHandlers.cs"
+    "declaringClass": "APIDataLinkHandler"
   },
   {
     "key": "a.schema",
@@ -63,8 +61,7 @@
     "alwaysEvaluable": true,
     "category": "system",
     "returnType": "object",
-    "declaringClass": "APIDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/SystemHandlers.cs"
+    "declaringClass": "APIDataLinkHandler"
   },
   {
     "key": "a.version",
@@ -75,8 +72,19 @@
     "alwaysEvaluable": true,
     "category": "system",
     "returnType": "string",
-    "declaringClass": "APIDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/SystemHandlers.cs"
+    "declaringClass": "APIDataLinkHandler"
+  },
+  {
+    "key": "alarm.add",
+    "description": "Create a stock-clock alarm. Args: title, ut, [warpAction], [message]. warpAction = DoNothing | KillWarp | PauseGame (default KillWarp). message = No | Yes | YesIfOtherVessel (default Yes). Returns the new alarm's id (uint), or an error string.",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "alarm",
+    "returnType": "object",
+    "params": "string title, double ut, string warpAction, string message",
+    "declaringClass": "AlarmClockDataLinkHandler"
   },
   {
     "key": "alarm.count",
@@ -84,11 +92,22 @@
     "units": "UNITLESS",
     "plotable": true,
     "isAction": false,
-    "alwaysEvaluable": false,
+    "alwaysEvaluable": true,
     "category": "alarm",
     "returnType": "int",
-    "declaringClass": "AlarmClockDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AlarmClockHandlers.cs"
+    "declaringClass": "AlarmClockDataLinkHandler"
+  },
+  {
+    "key": "alarm.delete",
+    "description": "Remove a stock-clock alarm by id. Args: id. Returns true if the alarm was found and queued for removal, false if no alarm with that id exists right now.",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "alarm",
+    "returnType": "bool",
+    "params": "uint id",
+    "declaringClass": "AlarmClockDataLinkHandler"
   },
   {
     "key": "alarm.list",
@@ -96,12 +115,11 @@
     "units": "UNITLESS",
     "plotable": false,
     "isAction": false,
-    "alwaysEvaluable": false,
+    "alwaysEvaluable": true,
     "category": "alarm",
     "returnType": "object",
     "formatter": "AlarmList",
-    "declaringClass": "AlarmClockDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AlarmClockHandlers.cs"
+    "declaringClass": "AlarmClockDataLinkHandler"
   },
   {
     "key": "alarm.nextAlarm",
@@ -109,12 +127,11 @@
     "units": "UNITLESS",
     "plotable": false,
     "isAction": false,
-    "alwaysEvaluable": false,
+    "alwaysEvaluable": true,
     "category": "alarm",
     "returnType": "object",
     "formatter": "Alarm",
-    "declaringClass": "AlarmClockDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AlarmClockHandlers.cs"
+    "declaringClass": "AlarmClockDataLinkHandler"
   },
   {
     "key": "alarm.timeToNext",
@@ -122,11 +139,10 @@
     "units": "TIME",
     "plotable": true,
     "isAction": false,
-    "alwaysEvaluable": false,
+    "alwaysEvaluable": true,
     "category": "alarm",
     "returnType": "double",
-    "declaringClass": "AlarmClockDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AlarmClockHandlers.cs"
+    "declaringClass": "AlarmClockDataLinkHandler"
   },
   {
     "key": "astg.active",
@@ -135,8 +151,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.activeTransfer",
@@ -145,8 +160,7 @@
     "plotable": false,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.available",
@@ -155,8 +169,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": true,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.createManeuver",
@@ -165,8 +178,7 @@
     "plotable": true,
     "isAction": true,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.errorCondition",
@@ -175,8 +187,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.hyperbolicOrbit",
@@ -185,8 +196,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.nextBurnCountdown",
@@ -195,8 +205,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.nextBurnTime",
@@ -205,8 +214,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.nextDeltaV",
@@ -215,8 +223,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.nextDestination",
@@ -225,8 +232,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.retrogradeOrbit",
@@ -235,8 +241,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.transfer",
@@ -245,8 +250,7 @@
     "plotable": false,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.transferCount",
@@ -255,8 +259,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.transfers",
@@ -265,8 +268,7 @@
     "plotable": false,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.warpToBurn",
@@ -275,8 +277,7 @@
     "plotable": true,
     "isAction": true,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "b.angularV",
@@ -288,8 +289,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.atmosphere",
@@ -301,8 +301,7 @@
     "category": "body",
     "returnType": "bool",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.atmosphereContainsOxygen",
@@ -314,8 +313,7 @@
     "category": "body",
     "returnType": "bool",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.description",
@@ -327,8 +325,7 @@
     "category": "body",
     "returnType": "string",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.geeASL",
@@ -340,8 +337,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.hillSphere",
@@ -353,8 +349,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.index",
@@ -366,8 +361,7 @@
     "category": "body",
     "returnType": "int",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.mass",
@@ -379,8 +373,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.maxAtmosphere",
@@ -392,8 +385,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.name",
@@ -405,8 +397,7 @@
     "category": "body",
     "returnType": "string",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.number",
@@ -417,8 +408,7 @@
     "alwaysEvaluable": false,
     "category": "body",
     "returnType": "int",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.ApA",
@@ -430,8 +420,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.argumentOfPeriapsis",
@@ -443,8 +432,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.eccentricity",
@@ -456,8 +444,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.gravParameter",
@@ -469,8 +456,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.inclination",
@@ -482,8 +468,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.lan",
@@ -495,8 +480,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.maae",
@@ -508,8 +492,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.PeA",
@@ -521,8 +504,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.period",
@@ -534,8 +516,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.phaseAngle",
@@ -547,8 +528,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.relativeVelocity",
@@ -560,8 +540,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.sma",
@@ -573,8 +552,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.timeOfPeriapsisPassage",
@@ -586,8 +564,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.timeToAp",
@@ -599,8 +576,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.timeToPe",
@@ -612,8 +588,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.timeToTransition1",
@@ -625,8 +600,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.timeToTransition2",
@@ -638,8 +612,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.trueAnomaly",
@@ -651,8 +624,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.truePositionAtUT",
@@ -665,8 +637,7 @@
     "returnType": "Vector3d",
     "params": "int bodyId, double UT",
     "formatter": "Vector3d",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.ocean",
@@ -678,8 +649,7 @@
     "category": "body",
     "returnType": "bool",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.orbitingBodies",
@@ -692,8 +662,7 @@
     "returnType": "string[]",
     "params": "int bodyId",
     "formatter": "StringArray",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.position",
@@ -706,8 +675,7 @@
     "returnType": "Vector3d",
     "params": "int bodyId",
     "formatter": "Vector3d",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.radius",
@@ -719,8 +687,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.referenceBody",
@@ -732,8 +699,7 @@
     "category": "body",
     "returnType": "string",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.rotates",
@@ -745,8 +711,7 @@
     "category": "body",
     "returnType": "bool",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.rotationAngle",
@@ -758,8 +723,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.rotationPeriod",
@@ -771,8 +735,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.soi",
@@ -784,8 +747,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.tidallyLocked",
@@ -797,8 +759,7 @@
     "category": "body",
     "returnType": "bool",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.timeWarpAltitudeLimits",
@@ -810,8 +771,7 @@
     "category": "body",
     "returnType": "object",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "career.funds",
@@ -822,8 +782,7 @@
     "alwaysEvaluable": true,
     "category": "career",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "career.mode",
@@ -834,8 +793,7 @@
     "alwaysEvaluable": true,
     "category": "career",
     "returnType": "string",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "career.reputation",
@@ -846,8 +804,7 @@
     "alwaysEvaluable": true,
     "category": "career",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "career.science",
@@ -858,8 +815,7 @@
     "alwaysEvaluable": true,
     "category": "career",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "comm.connected",
@@ -870,8 +826,7 @@
     "alwaysEvaluable": false,
     "category": "comms",
     "returnType": "bool",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "comm.controlState",
@@ -882,8 +837,7 @@
     "alwaysEvaluable": false,
     "category": "comms",
     "returnType": "int",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "comm.controlStateName",
@@ -894,8 +848,7 @@
     "alwaysEvaluable": false,
     "category": "comms",
     "returnType": "string",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "comm.signalDelay",
@@ -906,8 +859,7 @@
     "alwaysEvaluable": false,
     "category": "comms",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "comm.signalStrength",
@@ -918,8 +870,7 @@
     "alwaysEvaluable": false,
     "category": "comms",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "dock.ax",
@@ -930,8 +881,7 @@
     "alwaysEvaluable": false,
     "category": "docking",
     "returnType": "double",
-    "declaringClass": "DockingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "DockingDataLinkHandler"
   },
   {
     "key": "dock.ay",
@@ -942,8 +892,7 @@
     "alwaysEvaluable": false,
     "category": "docking",
     "returnType": "double",
-    "declaringClass": "DockingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "DockingDataLinkHandler"
   },
   {
     "key": "dock.az",
@@ -954,8 +903,7 @@
     "alwaysEvaluable": false,
     "category": "docking",
     "returnType": "double",
-    "declaringClass": "DockingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "DockingDataLinkHandler"
   },
   {
     "key": "dock.x",
@@ -966,8 +914,7 @@
     "alwaysEvaluable": false,
     "category": "docking",
     "returnType": "double",
-    "declaringClass": "DockingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "DockingDataLinkHandler"
   },
   {
     "key": "dock.y",
@@ -978,8 +925,7 @@
     "alwaysEvaluable": false,
     "category": "docking",
     "returnType": "double",
-    "declaringClass": "DockingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "DockingDataLinkHandler"
   },
   {
     "key": "dv.ready",
@@ -990,8 +936,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "double",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stage",
@@ -1004,8 +949,7 @@
     "returnType": "object",
     "params": "int stage",
     "formatter": "DeltaVStageInfo",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageBurnTime",
@@ -1017,8 +961,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageCount",
@@ -1029,8 +972,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "int",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageDryMass",
@@ -1042,8 +984,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageDVActual",
@@ -1055,8 +996,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageDVASL",
@@ -1068,8 +1008,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageDVVac",
@@ -1081,8 +1020,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageEndMass",
@@ -1094,8 +1032,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageFuelMass",
@@ -1107,8 +1044,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageISPActual",
@@ -1120,8 +1056,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageISPASL",
@@ -1133,8 +1068,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageISPVac",
@@ -1146,8 +1080,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageMass",
@@ -1159,8 +1092,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stages",
@@ -1172,8 +1104,7 @@
     "category": "deltav",
     "returnType": "object",
     "formatter": "DeltaVStageInfoList",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageStartMass",
@@ -1185,8 +1116,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageThrustActual",
@@ -1198,8 +1128,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageThrustASL",
@@ -1211,8 +1140,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageThrustVac",
@@ -1224,8 +1152,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageTWRActual",
@@ -1237,8 +1164,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageTWRASL",
@@ -1250,8 +1176,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageTWRVac",
@@ -1263,8 +1188,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.totalBurnTime",
@@ -1275,8 +1199,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "double",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.totalDVActual",
@@ -1287,8 +1210,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "double",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.totalDVASL",
@@ -1299,8 +1221,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "double",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.totalDVVac",
@@ -1311,8 +1232,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "double",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "f.abort",
@@ -1453,8 +1373,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.killRot",
@@ -1465,8 +1384,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.light",
@@ -1487,8 +1405,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.pitchTrim",
@@ -1499,8 +1416,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.precisionControl",
@@ -1531,8 +1447,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.rollTrim",
@@ -1543,8 +1458,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.sas",
@@ -1565,8 +1479,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.sasMode",
@@ -1577,8 +1490,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "string",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.setPitchTrim",
@@ -1590,8 +1502,7 @@
     "category": "flight",
     "returnType": "int",
     "params": "float trim",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.setRollTrim",
@@ -1603,8 +1514,7 @@
     "category": "flight",
     "returnType": "int",
     "params": "float trim",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.setSASMode",
@@ -1616,8 +1526,7 @@
     "category": "flight",
     "returnType": "string",
     "params": "string mode",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.setThrottle",
@@ -1639,8 +1548,7 @@
     "category": "flight",
     "returnType": "int",
     "params": "float trim",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.stage",
@@ -1660,8 +1568,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.throttleDown",
@@ -1708,8 +1615,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.yawInput",
@@ -1720,8 +1626,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.yawTrim",
@@ -1732,8 +1637,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.yInput",
@@ -1744,8 +1648,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.zInput",
@@ -1756,8 +1659,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "far.aoa",
@@ -1769,8 +1671,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.available",
@@ -1782,8 +1683,7 @@
     "category": "far",
     "returnType": "bool",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.ballisticCoeff",
@@ -1795,8 +1695,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.decreaseFlaps",
@@ -1808,8 +1707,7 @@
     "category": "far",
     "returnType": "bool",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.dragCoeff",
@@ -1821,8 +1719,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.dynPres",
@@ -1834,8 +1731,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.flapSetting",
@@ -1847,8 +1743,7 @@
     "category": "far",
     "returnType": "int",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.increaseFlaps",
@@ -1860,8 +1755,7 @@
     "category": "far",
     "returnType": "bool",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.liftCoeff",
@@ -1873,8 +1767,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.refArea",
@@ -1886,8 +1779,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.setSpoilers",
@@ -1900,8 +1792,7 @@
     "returnType": "bool",
     "params": "bool active",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.sideslip",
@@ -1913,8 +1804,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.spoiler",
@@ -1926,8 +1816,7 @@
     "category": "far",
     "returnType": "bool",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.stallFrac",
@@ -1939,8 +1828,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.termVel",
@@ -1952,8 +1840,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.tsfc",
@@ -1965,8 +1852,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.voxelized",
@@ -1978,8 +1864,7 @@
     "category": "far",
     "returnType": "bool",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "kerbalism.available",
@@ -1991,8 +1876,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.breathable",
@@ -2004,8 +1888,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.co2Level",
@@ -2017,8 +1900,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.connection",
@@ -2030,8 +1912,7 @@
     "category": "kerbalism",
     "returnType": "object",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.connectionLinked",
@@ -2043,8 +1924,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.connectionRate",
@@ -2056,8 +1936,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.connectionTransmitting",
@@ -2069,8 +1948,7 @@
     "category": "kerbalism",
     "returnType": "int",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.crew",
@@ -2082,8 +1960,7 @@
     "category": "kerbalism",
     "returnType": "object",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.critical",
@@ -2095,8 +1972,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.drivesCapacity",
@@ -2108,8 +1984,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.drivesFreeSpace",
@@ -2121,8 +1996,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.envStormRadiation",
@@ -2134,8 +2008,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.envTempDiff",
@@ -2147,8 +2020,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.envTemperature",
@@ -2160,8 +2032,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.experimentRunning",
@@ -2173,8 +2044,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.features",
@@ -2186,8 +2056,7 @@
     "category": "kerbalism",
     "returnType": "object",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatComfort",
@@ -2199,8 +2068,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatLivingSpace",
@@ -2212,8 +2080,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatPressure",
@@ -2225,8 +2092,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatRadiation",
@@ -2238,8 +2104,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatSurface",
@@ -2251,8 +2116,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatVolume",
@@ -2264,8 +2128,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.inAtmosphere",
@@ -2277,8 +2140,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.innerBelt",
@@ -2290,8 +2152,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.magnetosphere",
@@ -2303,8 +2164,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.malfunction",
@@ -2316,8 +2176,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.outerBelt",
@@ -2329,8 +2188,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.radiation",
@@ -2342,8 +2200,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.radiationEnabled",
@@ -2355,8 +2212,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.radiationShielding",
@@ -2368,8 +2224,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.solarExposure",
@@ -2381,8 +2236,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarActivity",
@@ -2394,8 +2248,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarStormDuration",
@@ -2407,8 +2260,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarStormIncoming",
@@ -2420,8 +2272,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarStormInProgress",
@@ -2433,8 +2284,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarStormStartTime",
@@ -2446,8 +2296,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarStormState",
@@ -2459,8 +2308,7 @@
     "category": "kerbalism",
     "returnType": "int",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "land.bestSpeedAtImpact",
@@ -2471,8 +2319,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.predictedAlt",
@@ -2483,8 +2330,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.predictedLat",
@@ -2495,8 +2341,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.predictedLon",
@@ -2507,8 +2352,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.slopeAngle",
@@ -2519,8 +2363,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.speedAtImpact",
@@ -2531,8 +2374,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.suicideBurnCountdown",
@@ -2543,8 +2385,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.timeToImpact",
@@ -2555,8 +2396,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "m.mapIsEnabled",
@@ -2567,8 +2407,7 @@
     "alwaysEvaluable": false,
     "category": "map",
     "returnType": "bool",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "mj.available",
@@ -2580,8 +2419,7 @@
     "category": "mechjeb",
     "returnType": "bool",
     "requiresMod": "mechjeb",
-    "declaringClass": "MechJebDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/MechJebDataLinkHandler.cs"
+    "declaringClass": "MechJebDataLinkHandler"
   },
   {
     "key": "mj.node",
@@ -2764,8 +2602,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.heading2",
@@ -2776,8 +2613,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.pitch",
@@ -2788,8 +2624,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.pitch2",
@@ -2800,8 +2635,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawheading",
@@ -2812,8 +2646,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawheading2",
@@ -2824,8 +2657,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawpitch",
@@ -2836,8 +2668,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawpitch2",
@@ -2848,8 +2679,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawroll",
@@ -2860,8 +2690,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawroll2",
@@ -2872,8 +2701,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.roll",
@@ -2884,8 +2712,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.roll2",
@@ -2896,8 +2723,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "o.addManeuverNode",
@@ -2910,8 +2736,7 @@
     "returnType": "object",
     "params": "float ut, float x, float y, float z",
     "formatter": "ManeuverNode",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.anVec",
@@ -2923,8 +2748,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.ApA",
@@ -2935,8 +2759,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.ApR",
@@ -2947,8 +2770,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.argumentOfPeriapsis",
@@ -2959,8 +2781,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.closestEncounterBody",
@@ -2971,8 +2792,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.closestTgtApprUT",
@@ -2983,8 +2803,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.eccentricAnomaly",
@@ -2995,8 +2814,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.eccentricity",
@@ -3007,8 +2825,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.eccVec",
@@ -3020,8 +2837,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.encounterBody",
@@ -3032,8 +2848,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.encounterExists",
@@ -3044,8 +2859,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "int",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.encounterTime",
@@ -3056,8 +2870,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.EndUT",
@@ -3068,8 +2881,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.epoch",
@@ -3080,8 +2892,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.gameLanguage",
@@ -3092,8 +2903,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "LangDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "LangDataLinkHandler"
   },
   {
     "key": "o.h",
@@ -3105,8 +2915,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.inclination",
@@ -3117,8 +2926,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.lan",
@@ -3129,8 +2937,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.maae",
@@ -3141,8 +2948,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes",
@@ -3154,8 +2960,7 @@
     "category": "maneuver",
     "returnType": "object",
     "formatter": "ManeuverNodeList",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.burnVector",
@@ -3168,8 +2973,7 @@
     "returnType": "Vector3d",
     "params": "int id",
     "formatter": "Vector3d",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.count",
@@ -3180,8 +2984,7 @@
     "alwaysEvaluable": false,
     "category": "maneuver",
     "returnType": "int",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.deltaV",
@@ -3194,8 +2997,7 @@
     "returnType": "Vector3d",
     "params": "int id",
     "formatter": "Vector3d",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.deltaVMagnitude",
@@ -3207,8 +3009,7 @@
     "category": "maneuver",
     "returnType": "double",
     "params": "int id",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.orbitPatches",
@@ -3221,8 +3022,7 @@
     "returnType": "object",
     "params": "int id",
     "formatter": "OrbitPatchList",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.relativePositionAtTrueAnomalyForManeuverNodesOrbitPatch",
@@ -3235,8 +3035,7 @@
     "returnType": "Vector3d",
     "params": "int id, int patchIndex, double trueAnomaly",
     "formatter": "Vector3d",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.relativePositionAtUTForManeuverNodesOrbitPatch",
@@ -3249,8 +3048,7 @@
     "returnType": "Vector3d",
     "params": "int id, int patchIndex, double UT",
     "formatter": "Vector3d",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.timeTo",
@@ -3262,8 +3060,7 @@
     "category": "maneuver",
     "returnType": "double",
     "params": "int id",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.trueAnomalyAtUTForManeuverNodesOrbitPatch",
@@ -3275,8 +3072,7 @@
     "category": "maneuver",
     "returnType": "double",
     "params": "int id, int patchIndex, double UT",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.UT",
@@ -3288,8 +3084,7 @@
     "category": "maneuver",
     "returnType": "double",
     "params": "int id",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.UTForTrueAnomalyForManeuverNodesOrbitPatch",
@@ -3301,8 +3096,7 @@
     "category": "maneuver",
     "returnType": "double",
     "params": "int id, int patchIndex, double trueAnomaly",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.mean.anomalisticPeriod",
@@ -3314,8 +3108,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.ApA",
@@ -3327,8 +3120,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.ApARange",
@@ -3340,8 +3132,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.argumentOfPeriapsis",
@@ -3353,8 +3144,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.eccentricity",
@@ -3366,8 +3156,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.eccentricityRange",
@@ -3379,8 +3168,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.inclination",
@@ -3392,8 +3180,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.inclinationRange",
@@ -3405,8 +3192,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.lan",
@@ -3418,8 +3204,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.nodalPeriod",
@@ -3431,8 +3216,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.nodalPrecession",
@@ -3444,8 +3228,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.PeA",
@@ -3457,8 +3240,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.PeARange",
@@ -3470,8 +3252,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.recurrence",
@@ -3483,8 +3264,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.siderealPeriod",
@@ -3496,8 +3276,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.sma",
@@ -3509,8 +3288,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.smaRange",
@@ -3522,8 +3300,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.meanAnomaly",
@@ -3534,8 +3311,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.nextApsisType",
@@ -3546,8 +3322,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitalEnergy",
@@ -3558,8 +3333,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitalSpeed",
@@ -3570,8 +3344,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitalSpeedAt",
@@ -3583,8 +3356,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "double obt",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitalSpeedAtDistance",
@@ -3596,8 +3368,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "double distance",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitNormal",
@@ -3609,8 +3380,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitPatches",
@@ -3622,8 +3392,7 @@
     "category": "orbit",
     "returnType": "object",
     "formatter": "OrbitPatchList",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitPercent",
@@ -3634,8 +3403,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.patchEndTransition",
@@ -3646,8 +3414,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.patchStartTransition",
@@ -3658,8 +3425,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.PeA",
@@ -3670,8 +3436,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.PeR",
@@ -3682,8 +3447,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.period",
@@ -3694,8 +3458,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.pos",
@@ -3707,8 +3470,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.radius",
@@ -3719,8 +3481,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.radiusAtTrueAnomaly",
@@ -3732,8 +3493,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "double trueAnomaly",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.referenceBody",
@@ -3744,8 +3504,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.relativePositionAtTrueAnomalyForOrbitPatch",
@@ -3758,8 +3517,7 @@
     "returnType": "Vector3d",
     "params": "int patchIndex, double trueAnomaly",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.relativePositionAtUTForOrbitPatch",
@@ -3772,8 +3530,7 @@
     "returnType": "Vector3d",
     "params": "int patchIndex, double UT",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.relativeVelocity",
@@ -3784,8 +3541,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.removeManeuverNode",
@@ -3797,8 +3553,7 @@
     "category": "maneuver",
     "returnType": "bool",
     "params": "int id",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.semiLatusRectum",
@@ -3809,8 +3564,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.semiMinorAxis",
@@ -3821,8 +3575,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.sma",
@@ -3833,8 +3586,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.StartUT",
@@ -3845,8 +3597,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeOfPeriapsisPassage",
@@ -3857,8 +3608,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeToAp",
@@ -3869,8 +3619,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeToNextApsis",
@@ -3881,8 +3630,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeToPe",
@@ -3893,8 +3641,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeToTransition1",
@@ -3905,8 +3652,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeToTransition2",
@@ -3917,8 +3663,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.trueAnomaly",
@@ -3929,8 +3674,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.trueAnomalyAtRadius",
@@ -3942,8 +3686,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "double radius",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.trueAnomalyAtUTForOrbitPatch",
@@ -3955,8 +3698,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "int patchIndex, double UT",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.updateManeuverNode",
@@ -3969,8 +3711,7 @@
     "returnType": "object",
     "params": "int id, float ut, float x, float y, float z",
     "formatter": "ManeuverNode",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.UTForTrueAnomalyForOrbitPatch",
@@ -3982,8 +3723,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "int patchIndex, double trueAnomaly",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.UTsoi",
@@ -3994,8 +3734,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.vel",
@@ -4007,8 +3746,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "p.paused",
@@ -4019,8 +3757,7 @@
     "alwaysEvaluable": true,
     "category": "system",
     "returnType": "int",
-    "declaringClass": "PausedDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/SystemHandlers.cs"
+    "declaringClass": "PausedDataLinkHandler"
   },
   {
     "key": "principia.active",
@@ -4032,8 +3769,7 @@
     "category": "principia",
     "returnType": "bool",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.analysis",
@@ -4045,8 +3781,7 @@
     "category": "principia",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.analysisProgress",
@@ -4058,8 +3793,7 @@
     "category": "principia",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.available",
@@ -4071,8 +3805,7 @@
     "category": "principia",
     "returnType": "bool",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.missionDuration",
@@ -4084,8 +3817,7 @@
     "category": "principia",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.plan.burn",
@@ -4098,8 +3830,7 @@
     "returnType": "object",
     "params": "int index",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.plan.burns",
@@ -4111,8 +3842,7 @@
     "category": "principia",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.plan.count",
@@ -4124,8 +3854,7 @@
     "category": "principia",
     "returnType": "int",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.plan.guidance",
@@ -4137,8 +3866,7 @@
     "category": "principia",
     "returnType": "bool",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.version",
@@ -4150,8 +3878,7 @@
     "category": "principia",
     "returnType": "string",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "r.resource",
@@ -4164,8 +3891,7 @@
     "returnType": "object",
     "params": "string resourceName",
     "formatter": "ResourceList",
-    "declaringClass": "ResourceDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "ResourceDataLinkHandler"
   },
   {
     "key": "r.resourceCurrent",
@@ -4178,8 +3904,7 @@
     "returnType": "object",
     "params": "string resourceName",
     "formatter": "ActiveResourceList",
-    "declaringClass": "ResourceDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "ResourceDataLinkHandler"
   },
   {
     "key": "r.resourceCurrentMax",
@@ -4192,8 +3917,7 @@
     "returnType": "object",
     "params": "string resourceName",
     "formatter": "MaxCurrentResourceList",
-    "declaringClass": "ResourceDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "ResourceDataLinkHandler"
   },
   {
     "key": "r.resourceMax",
@@ -4206,8 +3930,7 @@
     "returnType": "object",
     "params": "string resourceName",
     "formatter": "MaxResourceList",
-    "declaringClass": "ResourceDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "ResourceDataLinkHandler"
   },
   {
     "key": "r.resourceNameList",
@@ -4219,8 +3942,7 @@
     "category": "resource",
     "returnType": "string[]",
     "formatter": "StringArray",
-    "declaringClass": "ResourceDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "ResourceDataLinkHandler"
   },
   {
     "key": "rc.anyDeployed",
@@ -4232,8 +3954,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.arm",
@@ -4245,8 +3966,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.available",
@@ -4258,8 +3978,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.chutes",
@@ -4271,8 +3990,7 @@
     "category": "realchute",
     "returnType": "object",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.count",
@@ -4284,8 +4002,7 @@
     "category": "realchute",
     "returnType": "int",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.cut",
@@ -4297,8 +4014,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.deploy",
@@ -4310,8 +4026,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.disarm",
@@ -4323,8 +4038,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.safeState",
@@ -4336,8 +4050,7 @@
     "category": "realchute",
     "returnType": "string",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "s.sensor",
@@ -4350,8 +4063,7 @@
     "returnType": "object",
     "params": "string sensorType",
     "formatter": "SensorModuleList",
-    "declaringClass": "SensorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "SensorDataLinkHandler"
   },
   {
     "key": "s.sensor.acc",
@@ -4363,8 +4075,7 @@
     "category": "sensor",
     "returnType": "object",
     "formatter": "SensorModuleList",
-    "declaringClass": "SensorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "SensorDataLinkHandler"
   },
   {
     "key": "s.sensor.grav",
@@ -4376,8 +4087,7 @@
     "category": "sensor",
     "returnType": "object",
     "formatter": "SensorModuleList",
-    "declaringClass": "SensorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "SensorDataLinkHandler"
   },
   {
     "key": "s.sensor.pres",
@@ -4389,8 +4099,7 @@
     "category": "sensor",
     "returnType": "object",
     "formatter": "SensorModuleList",
-    "declaringClass": "SensorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "SensorDataLinkHandler"
   },
   {
     "key": "s.sensor.temp",
@@ -4402,8 +4111,7 @@
     "category": "sensor",
     "returnType": "object",
     "formatter": "SensorModuleList",
-    "declaringClass": "SensorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "SensorDataLinkHandler"
   },
   {
     "key": "sci.count",
@@ -4414,8 +4122,7 @@
     "alwaysEvaluable": false,
     "category": "science",
     "returnType": "int",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "sci.dataAmount",
@@ -4426,8 +4133,7 @@
     "alwaysEvaluable": false,
     "category": "science",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "sci.experiments",
@@ -4438,8 +4144,7 @@
     "alwaysEvaluable": false,
     "category": "science",
     "returnType": "object",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "t.currentRate",
@@ -4450,8 +4155,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "double",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.currentRateIndex",
@@ -4462,8 +4166,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "double",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.deltaTime",
@@ -4474,8 +4177,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "double",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.isPaused",
@@ -4486,8 +4188,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "bool",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.maxPhysicsRate",
@@ -4498,8 +4199,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "double",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.universalTime",
@@ -4510,8 +4210,7 @@
     "alwaysEvaluable": true,
     "category": "timewarp",
     "returnType": "double",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.warpMode",
@@ -4522,8 +4221,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "string",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "tar.clearTarget",
@@ -4534,8 +4232,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "int",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.distance",
@@ -4546,8 +4243,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.groundDistance",
@@ -4558,8 +4254,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.name",
@@ -4570,8 +4265,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "string",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.ApA",
@@ -4582,8 +4276,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.argumentOfPeriapsis",
@@ -4594,8 +4287,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.eccentricity",
@@ -4606,8 +4298,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.inclination",
@@ -4618,8 +4309,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.lan",
@@ -4630,8 +4320,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.maae",
@@ -4642,8 +4331,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.orbitingBody",
@@ -4654,8 +4342,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "string",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.orbitPatches",
@@ -4667,8 +4354,7 @@
     "category": "target",
     "returnType": "double",
     "formatter": "OrbitPatchList",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.PeA",
@@ -4679,8 +4365,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.period",
@@ -4691,8 +4376,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.relativeInclination",
@@ -4703,8 +4387,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.relativePositionAtTrueAnomalyForOrbitPatch",
@@ -4717,8 +4400,7 @@
     "returnType": "double",
     "params": "int orbitPatchIndex, float trueAnomaly",
     "formatter": "Vector3d",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.relativePositionAtUTForOrbitPatch",
@@ -4731,8 +4413,7 @@
     "returnType": "double",
     "params": "int orbitPatchIndex, double universalTime",
     "formatter": "Vector3d",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.relativeVelocity",
@@ -4743,8 +4424,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.sma",
@@ -4755,8 +4435,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.timeOfPeriapsisPassage",
@@ -4767,8 +4446,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.timeToAp",
@@ -4779,8 +4457,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.timeToPe",
@@ -4791,8 +4468,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.timeToTransition1",
@@ -4803,8 +4479,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.timeToTransition2",
@@ -4815,8 +4490,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.trueAnomaly",
@@ -4827,8 +4501,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.trueAnomalyAtUTForOrbitPatch",
@@ -4840,8 +4513,7 @@
     "category": "target",
     "returnType": "double",
     "params": "int orbitPatchIndex, float universalTime",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.UTForTrueAnomalyForOrbitPatch",
@@ -4853,8 +4525,7 @@
     "category": "target",
     "returnType": "double",
     "params": "int orbitPatchIndex, float trueAnomaly",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.velocity",
@@ -4865,8 +4536,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.setTargetBody",
@@ -4878,8 +4548,7 @@
     "category": "target",
     "returnType": "int",
     "params": "int bodyId",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.setTargetVessel",
@@ -4891,8 +4560,7 @@
     "category": "target",
     "returnType": "int",
     "params": "int vesselIndex",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.type",
@@ -4903,8 +4571,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "string",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "therm.anyEnginesOverheating",
@@ -4915,8 +4582,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "bool",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.heatShieldFlux",
@@ -4927,8 +4593,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.heatShieldTemp",
@@ -4939,8 +4604,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.heatShieldTempCelsius",
@@ -4951,8 +4615,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestEngineMaxTemp",
@@ -4963,8 +4626,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestEngineTemp",
@@ -4975,8 +4637,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestEngineTempRatio",
@@ -4987,8 +4648,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestPartMaxTemp",
@@ -4999,8 +4659,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestPartName",
@@ -5011,8 +4670,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "string",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestPartTemp",
@@ -5023,8 +4681,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestPartTempKelvin",
@@ -5035,8 +4692,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestPartTempRatio",
@@ -5047,8 +4703,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "v.abortValue",
@@ -5059,8 +4714,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.acceleration",
@@ -5071,8 +4725,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.accelerationx",
@@ -5083,8 +4736,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.accelerationy",
@@ -5095,8 +4747,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.accelerationz",
@@ -5107,8 +4758,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.ag10Value",
@@ -5119,8 +4769,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag1Value",
@@ -5131,8 +4780,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag2Value",
@@ -5143,8 +4791,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag3Value",
@@ -5155,8 +4802,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag4Value",
@@ -5167,8 +4813,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag5Value",
@@ -5179,8 +4824,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag6Value",
@@ -5191,8 +4835,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag7Value",
@@ -5203,8 +4846,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag8Value",
@@ -5215,8 +4857,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag9Value",
@@ -5227,8 +4868,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.altitude",
@@ -5239,8 +4879,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angleToPrograde",
@@ -5251,8 +4890,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularMomentum",
@@ -5263,8 +4901,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularMomentumx",
@@ -5275,8 +4912,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularMomentumy",
@@ -5287,8 +4923,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularMomentumz",
@@ -5299,8 +4934,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularVelocity",
@@ -5311,8 +4945,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularVelocityx",
@@ -5323,8 +4956,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularVelocityy",
@@ -5335,8 +4967,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularVelocityz",
@@ -5347,8 +4978,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.atmosphericDensity",
@@ -5359,8 +4989,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.atmosphericPressure",
@@ -5371,8 +5000,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.atmosphericPressurePa",
@@ -5383,8 +5011,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.atmosphericTemperature",
@@ -5395,8 +5022,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.biome",
@@ -5407,8 +5033,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.biomeLocalized",
@@ -5419,8 +5044,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.body",
@@ -5431,8 +5055,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.brakeValue",
@@ -5443,8 +5066,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.CoM",
@@ -5456,8 +5078,7 @@
     "category": "vessel",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.crew",
@@ -5469,8 +5090,7 @@
     "category": "vessel",
     "returnType": "string[]",
     "formatter": "StringArray",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.crewCapacity",
@@ -5481,8 +5101,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "int",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.crewCount",
@@ -5493,8 +5112,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "int",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.currentStage",
@@ -5505,8 +5123,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "int",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.directSunlight",
@@ -5517,8 +5134,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.distanceToSun",
@@ -5529,8 +5145,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.dynamicPressure",
@@ -5541,8 +5156,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.dynamicPressurekPa",
@@ -5553,8 +5167,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.externalTemperature",
@@ -5565,8 +5178,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.gearValue",
@@ -5577,8 +5189,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.geeForce",
@@ -5589,8 +5200,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.geeForceImmediate",
@@ -5601,8 +5211,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.heightFromSurface",
@@ -5613,8 +5222,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.heightFromTerrain",
@@ -5625,8 +5233,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.indicatedAirSpeed",
@@ -5637,8 +5244,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.isActiveVessel",
@@ -5649,8 +5255,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.isCommandable",
@@ -5661,8 +5266,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.isControllable",
@@ -5673,8 +5277,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.isEVA",
@@ -5685,8 +5288,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.landed",
@@ -5697,8 +5299,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.landedAt",
@@ -5709,8 +5310,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.landedOrSplashed",
@@ -5721,8 +5321,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.lat",
@@ -5733,8 +5332,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.launchTime",
@@ -5745,8 +5343,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.lightValue",
@@ -5757,8 +5354,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.loaded",
@@ -5769,8 +5365,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.long",
@@ -5781,8 +5376,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.mach",
@@ -5793,8 +5387,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.mass",
@@ -5805,8 +5398,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.missionTime",
@@ -5817,8 +5409,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.missionTimeString",
@@ -5829,8 +5420,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.momentOfInertia",
@@ -5842,8 +5432,7 @@
     "category": "vessel",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.name",
@@ -5854,8 +5443,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.obtSpeed",
@@ -5866,8 +5454,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.orbitalVelocity",
@@ -5878,8 +5465,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.orbitalVelocityx",
@@ -5890,8 +5476,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.orbitalVelocityy",
@@ -5902,8 +5487,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.orbitalVelocityz",
@@ -5914,8 +5498,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.packed",
@@ -5926,8 +5509,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.perturbation",
@@ -5938,8 +5520,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.perturbationx",
@@ -5950,8 +5531,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.perturbationy",
@@ -5962,8 +5542,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.perturbationz",
@@ -5974,8 +5553,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.pqsAltitude",
@@ -5986,8 +5564,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.precisionControlValue",
@@ -5998,8 +5575,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.rcsValue",
@@ -6010,8 +5586,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.sasValue",
@@ -6022,8 +5597,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.setAttitude",
@@ -6035,8 +5609,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float pitch, float yaw, float roll",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setFbW",
@@ -6048,8 +5621,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "int state",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setPitch",
@@ -6061,8 +5633,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float pitch",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setPitchYawRollXYZ",
@@ -6074,8 +5645,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float pitch, float yaw, float roll, float x, float y, float z",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setRoll",
@@ -6087,8 +5657,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float roll",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setTranslation",
@@ -6100,8 +5669,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float x, float y, float z",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setYaw",
@@ -6113,8 +5681,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float yaw",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.situation",
@@ -6125,8 +5692,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.situationString",
@@ -6137,8 +5703,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.solarFlux",
@@ -6149,8 +5714,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.specificAcceleration",
@@ -6161,8 +5725,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.speed",
@@ -6173,8 +5736,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.speedOfSound",
@@ -6185,8 +5747,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.splashed",
@@ -6197,8 +5758,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.srfSpeed",
@@ -6209,8 +5769,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.staticPressure",
@@ -6221,8 +5780,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.staticPressurekPa",
@@ -6233,8 +5791,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.surfaceSpeed",
@@ -6245,8 +5802,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.surfaceVelocity",
@@ -6257,8 +5813,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.surfaceVelocityx",
@@ -6269,8 +5824,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.surfaceVelocityy",
@@ -6281,8 +5835,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.surfaceVelocityz",
@@ -6293,8 +5846,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.terrainHeight",
@@ -6305,8 +5857,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.terrainNormal",
@@ -6318,8 +5869,7 @@
     "category": "vessel",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.upAxis",
@@ -6331,8 +5881,7 @@
     "category": "vessel",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.verticalSpeed",
@@ -6343,8 +5892,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.vesselType",
@@ -6355,7 +5903,6 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   }
 ]

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -300,6 +300,51 @@ paths:
                   a.version:
                     type: string
       x-plotable: true
+  "/api/alarm.add":
+    get:
+      summary: "Create a stock-clock alarm. Args: title, ut, [warpAction], [message]. warpAction = DoNothing | KillWarp | PauseGame (default KillWarp). message = No | Yes | YesIfOtherVessel (default Yes). Returns the new alarm's id (uint), or an error string."
+      operationId: alarm.add
+      tags:
+        - alarm
+      parameters:
+        - name: title
+          in: query
+          required: true
+          description: string parameter (passed via bracket notation)
+          schema:
+            type: string
+        - name: ut
+          in: query
+          required: true
+          description: double parameter (passed via bracket notation)
+          schema:
+            type: number
+        - name: warpAction
+          in: query
+          required: true
+          description: string parameter (passed via bracket notation)
+          schema:
+            type: string
+        - name: message
+          in: query
+          required: true
+          description: string parameter (passed via bracket notation)
+          schema:
+            type: string
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  alarm.add:
+                    type: object
+      x-plotable: true
   "/api/alarm.count":
     get:
       summary: Number of Active Alarms
@@ -320,6 +365,33 @@ paths:
                 properties:
                   alarm.count:
                     type: integer
+      x-plotable: true
+  "/api/alarm.delete":
+    get:
+      summary: "Remove a stock-clock alarm by id. Args: id. Returns true if the alarm was found and queued for removal, false if no alarm with that id exists right now."
+      operationId: alarm.delete
+      tags:
+        - alarm
+      parameters:
+        - name: id
+          in: query
+          required: true
+          description: uint parameter (passed via bracket notation)
+          schema:
+            type: string
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  alarm.delete:
+                    type: boolean
       x-plotable: true
   "/api/alarm.list":
     get:

--- a/tools/generate-openapi.ts
+++ b/tools/generate-openapi.ts
@@ -481,7 +481,9 @@ const outPath = resolve(outDir, "openapi.yaml");
 writeFileSync(outPath, yaml + "\n");
 console.log(`Written ${outPath}`);
 
-// Also write the merged JSON for easy consumption
+// Also write the merged JSON for easy consumption.
+// `sourceFile` is omitted here — kept on the in-memory entries for tooling use, off the committed artifact.
 const mergedJsonPath = resolve(outDir, "api-schema.json");
-writeFileSync(mergedJsonPath, JSON.stringify(all, null, 2) + "\n");
+const sanitized = all.map(({ sourceFile: _sourceFile, ...rest }) => rest);
+writeFileSync(mergedJsonPath, JSON.stringify(sanitized, null, 2) + "\n");
 console.log(`Written ${mergedJsonPath}`);


### PR DESCRIPTION
⚠️ I've used Claude to make this change and draft most of the description below. Built, tested locally in KSP, and happy with the result, so sharing here.

## Summary

Adds two action keys for stock-clock alarm management plus an `id` field in the alarm row.

```
alarm.add[title, ut, warpAction?, message?] → uint id    (or error string)
alarm.delete[id] → bool                                  (false if no such alarm)
```

`alarm.list` / `alarm.nextAlarm` rows now include `"id": <uint>` so external clients can address an alarm.

## Why not IsAction?

`alarm.add` needs to return the new alarm's `uint Id` synchronously in the HTTP response, but the existing `IsAction = true` path wraps the handler in `queueDelayed`, which short-circuits the return to `false` while the real work runs on the next Unity tick. So this PR manually queues the `AlarmClockScenario.AddAlarm` / `DeleteAlarm` call onto the main thread via the same `TelemachusBehaviour.queueDelayedAPI` hook the auto-defer uses, while the caller returns its own value sync.

The `AlarmTypeRaw` ctor calls `GetUniqueAlarmID()` synchronously, so `alarm.Id` is already set by the time it's read on the dispatch thread.

## Other small changes

- `alarm.count / alarm.list / alarm.nextAlarm / alarm.timeToNext` gain `AlwaysEvaluable = true` so they're queryable from Space Center / Tracking Station, not just Flight.

## Validation

Tested locally on KSP 1.12.x with KAC visible:

- `GET /telemachus/datalink?a=alarm.add[Test,1234567,KillWarp,Yes]` returned a fresh uint id and the alarm appeared in the stock KAC UI on the next tick.
- `GET /telemachus/datalink?a=alarm.list` rows include the new `id` field for each alarm, including ones not created via this API.
- `GET /telemachus/datalink?a=alarm.delete[<id>]` returns `true` for an existing alarm and `false` for an unknown id; the alarm disappears from the KAC UI on the next tick.
- Invalid `warpAction` / `message` enum values return a descriptive error string instead of throwing.
- All four read keys answer correctly from the Space Center scene (previously gated to Flight).
