### PR TITLE
fix: propagate AlwaysEvaluable through ActionAPIEntry

### DIFF
--- a/Telemachus/src/DataLinkHandlerBase.cs
+++ b/Telemachus/src/DataLinkHandlerBase.cs
@@ -76,8 +76,9 @@ namespace Telemachus
 
                 APIEntry entry;
                 if (attr.IsAction)
-                    // Action handlers must run on the main Unity thread
-                    entry = new ActionAPIEntry(queueDelayed(fn), attr.Key, attr.Description, formatter);
+                    // Action handlers run on the main Unity thread; propagate AlwaysEvaluable.
+                    entry = new ActionAPIEntry(queueDelayed(fn), attr.Key, attr.Description, formatter,
+                        attr.AlwaysEvaluable);
                 else if (attr.Plotable)
                     entry = new PlotableAPIEntry(fn, attr.Key, attr.Description,
                         formatter, attr.Units, attr.AlwaysEvaluable);
@@ -214,8 +215,10 @@ namespace Telemachus
     public class ActionAPIEntry : APIEntry
     {
         public ActionAPIEntry(DataLinkHandler.APIDelegate function,
-            string APIString, string name, DataSourceResultFormatter formatter)
-            : base(function, APIString, name, formatter, APIEntry.UnitType.UNITLESS)
+            string APIString, string name, DataSourceResultFormatter formatter,
+            bool alwaysEvaluable = false)
+            : base(function, APIString, name, formatter,
+                APIEntry.UnitType.UNITLESS, alwaysEvaluable)
         {
             plotable = false;
         }


### PR DESCRIPTION
⚠️ I've used Claude to make this change and draft most of the description below. Built, tested locally in KSP, and happy with the result, so sharing here.

## Summary

When `[TelemetryAPI(IsAction = true, AlwaysEvaluable = true)]` is used today, the `AlwaysEvaluable` part doesn't take effect. Tracing the registration path in `DataLinkHandlerBase.RegisterAnnotatedMethods`: `ActionAPIEntry` is constructed without `attr.AlwaysEvaluable` being passed through, and the existing `ActionAPIEntry` ctor doesn't accept the flag — so the `alwaysEvaluable` bool on the base `APIEntry` stays `false` for any attribute-registered action handler.

This PR threads `attr.AlwaysEvaluable` through `ActionAPIEntry` so the attribute takes effect.

## Behaviour preservation

No existing handler in the codebase combines `IsAction = true` + `AlwaysEvaluable = true` today, so this change has no observable effect on shipped behaviour. The flag only becomes load-bearing for handlers that future work introduces (I have a couple in flight that need it for tech-tree / alarm-add invocations from outside Flight).

`ActionAPIEntry`'s ctor takes the new bool as a defaulted optional parameter, so any existing manual call sites remain source-compatible.

## A caveat

If the original intent was for `IsAction` handlers to be Flight-only by design — i.e. `AlwaysEvaluable` was meant to be ignored on them — happy to revisit. This PR assumes the attribute combination was meant to work and the gap is unintentional; couldn't find a comment or test pinning the intent down either way.

## Validation

Built locally and verified the existing action surface didn't regress:

- `f.ag1` / `f.stage` / `f.setThrottle` continue to fire correctly from Flight and refuse outside Flight (no observable change vs trunk).
- A practical test of the fix's effect lives in #86, where the new `tech.unlock` / `contracts.*` / `kc.upgradeFacility` / `ksp.launch` action keys (all `IsAction + AlwaysEvaluable`) become dispatchable from the Space Center / Editor / Tracking Station scenes only with this change in place. Without it they're silently gated to Flight; with it they fire correctly outside Flight.
