### PR TITLE
feat: event-driven recovery / crash / flight-log snapshot handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,6 +702,21 @@ Example: `r.resource[ElectricCharge]`, `r.resource[LiquidFuel]`, `r.resource[Oxi
 | `alarm.nextAlarm` | Next alarm to trigger |
 | `alarm.timeToNext` | Time until next alarm (s) |
 
+### `recovery.*` / `crash.*` / `flight.*` — Mission outcomes
+
+Snapshot keys captured from `GameEvents` — readable from any scene (including Space Center / Tracking Station after the flight) so a dashboard can surface a "last outcome" panel.
+
+| Key | Description |
+|-----|-------------|
+| `recovery.lastSummary` | Last `MissionRecoveryDialog` content (vesselName, recoveryFactor, scienceEarned, fundsEarned, parts[], resources[], crew[]) + FlightLogger stats |
+| `recovery.hasRecent` | Whether a recovery snapshot is available |
+| `crash.lastCrash` | Vessel destruction event: crewAboard[], kerbalsKilled[], flightEndMode, + FlightLogger stats |
+| `crash.hasRecent` | Whether a crash snapshot is available |
+| `flight.events` | Current flight's `FlightLogger.eventLog` (live) |
+| `flight.achievements` | Highest altitude / speed / G / partsLost / etc. |
+
+> `PRELAUNCH` recovery (the cheap launchpad refund path) doesn't fire `onVesselRecoveryProcessingComplete` so it produces no snapshot. Flight-scene recoveries and the post-landing summary dialog both work.
+
 ### `m.*` — Map view
 
 | Key | Description |

--- a/README.md
+++ b/README.md
@@ -710,12 +710,43 @@ Snapshot keys captured from `GameEvents` — readable from any scene (including 
 |-----|-------------|
 | `recovery.lastSummary` | Last `MissionRecoveryDialog` content (vesselName, recoveryFactor, scienceEarned, fundsEarned, parts[], resources[], crew[]) + FlightLogger stats |
 | `recovery.hasRecent` | Whether a recovery snapshot is available |
-| `crash.lastCrash` | Vessel destruction event: crewAboard[], kerbalsKilled[], flightEndMode, + FlightLogger stats |
+| `crash.lastCrash` | Most recent notable-vessel crash — terrain, water, or non-collision loss (burn-up / structural). Debris/flags excluded. Full object below |
 | `crash.hasRecent` | Whether a crash snapshot is available |
 | `flight.events` | Current flight's `FlightLogger.eventLog` (live) |
 | `flight.achievements` | Highest altitude / speed / G / partsLost / etc. |
 
 > `PRELAUNCH` recovery (the cheap launchpad refund path) doesn't fire `onVesselRecoveryProcessingComplete` so it produces no snapshot. Flight-scene recoveries and the post-landing summary dialog both work.
+
+<details><summary><code>crash.lastCrash</code> — full object</summary>
+
+A single-slot "last notable crash", fed by three KSP signals: `onCrash` (terrain), `onCrashSplashdown` (water), and `onVesselWillDestroy` (a non-collision loss — re-entry burn-up, structural/aero break-up, or an impact so fast `CollisionEnhancer` destroyed the craft before a collision event fired). Persists across scenes; cleared on KSP restart.
+
+**Excluded** (never recorded): vessels of type `Debris`, `Flag`, or `Unknown` — spent boosters and the like won't clobber the slot and hide the real crash (`SpaceObject`/asteroids are kept, being pilotable). The `onVesselWillDestroy` path additionally requires the **active** vessel, a situation other than `PRELAUNCH`, and that no revert / recovery / scene change is in progress.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `eventKind` | string | `Crash` (terrain) · `CrashSplashdown` (water) · `Destroyed` (non-collision) |
+| `vesselName` | string | |
+| `vesselType` | string | KSP `VesselType` — `Ship`, `Probe`, `Lander`, `SpaceObject`, … (never Debris/Flag/Unknown) |
+| `vesselId` | string | vessel GUID |
+| `body` | string | celestial body, e.g. `Kerbin` |
+| `situation` | string | KSP situation at death — `FLYING`, `LANDED`, `SPLASHED`, … |
+| `latitude` / `longitude` / `altitude` | number | site of the event (4dp) |
+| `ut` | number | universal time |
+| `what` | string | what was struck — collision paths only; empty for `Destroyed` |
+| `msg` | string | collision message; empty for `Destroyed` |
+| `partsLost` | array | `{ partName, partTitle, partId, msg }` |
+| `crewAboard` | string[] | crew aboard at the time |
+| `kerbalsKilled` | string[] | crew killed |
+| `events` | string[] | `FlightLogger` event log (e.g. `"… exploded due to overheating: 2201 / 2200 K"`) |
+| `flightStats` | object | `FlightLogger` mission stats — `highestSpeed`, `highestAltitude`, `highestGee`, `flightEndMode`, … |
+
+Two value-shape notes:
+
+- **Collision** (`Crash` / `CrashSplashdown`): `partsLost` lists the parts that struck, coalesced over a 5 s window; `what` and `msg` are populated.
+- **`Destroyed`**: `what` and `msg` are empty, and `partsLost` is whatever parts remained at destroy time — often `[]` for a burn-up, since parts cook off individually before the vessel-destroy fires. The `events` log is then the record of what happened.
+
+</details>
 
 ### `m.*` — Map view
 

--- a/Telemachus/src/CrashDataHandler.cs
+++ b/Telemachus/src/CrashDataHandler.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Telemachus
+{
+    /// <summary>Vessel-crash snapshot — coalesces per-part onCrash events within a 5s window and buffers onCrewKilled (which fires before onCrash, so kills must be staged).</summary>
+    public class CrashDataHandler : DataLinkHandler
+    {
+        private const double CoalesceWindowSeconds = 5.0;
+
+        private static Dictionary<string, object> _lastCrash;
+        private static double _lastCrashUT;
+        private static string _lastCrashVesselId;
+
+        // onCrewKilled fires before onCrash — buffer kill names so they don't get lost when the snapshot is built.
+        private static readonly List<string> _pendingKerbalsKilled = new List<string>();
+
+        // Pre-tracked because KSP flips dead kerbals to RosterStatus.Dead before onCrash, and GetVesselCrew() filters Dead out.
+        private static List<string> _lastKnownCrew = new List<string>();
+        private static string _lastKnownCrewVesselId;
+
+        public CrashDataHandler(FormatterProvider formatters)
+            : base(formatters) { }
+
+        private static double R4(double v) => Math.Round(v, 4);
+        private static double R4(float v) => R4((double)v);
+
+        internal static void OnCrash(EventReport report) => CaptureCrash(report, "Crash");
+        internal static void OnCrashSplashdown(EventReport report) => CaptureCrash(report, "CrashSplashdown");
+
+        internal static void OnCrewKilled(EventReport report)
+        {
+            try
+            {
+                var name = report?.sender ?? string.Empty;
+                if (string.IsNullOrEmpty(name)) return;
+                if (!_pendingKerbalsKilled.Contains(name)) _pendingKerbalsKilled.Add(name);
+                if (_lastCrash != null
+                    && _lastCrash.TryGetValue("kerbalsKilled", out var raw)
+                    && raw is List<string> list
+                    && !list.Contains(name))
+                {
+                    list.Add(name);
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning("[Telemachus] crash crew capture failed: " + e.Message);
+            }
+        }
+
+        /// <summary>Sampled by the addon every ~0.5s — pre-crash crew, kept fresh because KSP wipes the live list before onCrash fires.</summary>
+        internal static void RefreshLiveCrew(string vesselId, List<string> crew)
+        {
+            if (vesselId == null) return;
+            // Non-empty wins on same vessel: a mid-crash wipe must not overwrite the last good sample.
+            if (vesselId != _lastKnownCrewVesselId)
+            {
+                _lastKnownCrewVesselId = vesselId;
+                _lastKnownCrew = new List<string>(crew);
+                return;
+            }
+            if (crew.Count > 0)
+            {
+                _lastKnownCrew = new List<string>(crew);
+            }
+        }
+
+        private static void CaptureCrash(EventReport report, string eventKind)
+        {
+            if (report == null) return;
+            try
+            {
+                var origin = report.origin;
+                var vessel = origin?.vessel;
+                var vesselId = vessel?.id.ToString() ?? string.Empty;
+                var ut = Planetarium.GetUniversalTime();
+
+                // Same vessel within window → append to existing snapshot.
+                if (_lastCrash != null
+                    && _lastCrashVesselId == vesselId
+                    && ut - _lastCrashUT < CoalesceWindowSeconds)
+                {
+                    AppendPart(_lastCrash, origin, report);
+                    _lastCrashUT = ut;
+                    return;
+                }
+
+                var crewAboard = _lastKnownCrew != null && _lastKnownCrew.Count > 0
+                    ? new List<string>(_lastKnownCrew)
+                    : ListCrewAboard(vessel);
+                var kerbalsKilled = new List<string>(_pendingKerbalsKilled);
+                _pendingKerbalsKilled.Clear();
+                var snap = new Dictionary<string, object>
+                {
+                    ["eventKind"] = eventKind,
+                    ["vesselName"] = vessel?.vesselName ?? report.sender ?? string.Empty,
+                    ["vesselId"] = vesselId,
+                    ["body"] = vessel?.mainBody?.bodyName ?? string.Empty,
+                    ["situation"] = vessel?.situation.ToString() ?? string.Empty,
+                    ["latitude"] = R4(vessel?.latitude ?? 0.0),
+                    ["longitude"] = R4(vessel?.longitude ?? 0.0),
+                    ["altitude"] = R4(vessel?.altitude ?? 0.0),
+                    ["ut"] = R4(ut),
+                    ["what"] = report.other ?? string.Empty,
+                    ["msg"] = report.msg ?? string.Empty,
+                    ["partsLost"] = new List<Dictionary<string, object>>(),
+                    ["crewAboard"] = crewAboard,
+                    ["kerbalsKilled"] = kerbalsKilled,
+                    ["events"] = FlightLoggerSnapshot.CaptureEvents(),
+                    ["flightStats"] = FlightLoggerSnapshot.Capture(),
+                };
+                AppendPart(snap, origin, report);
+                _lastCrash = snap;
+                _lastCrashUT = ut;
+                _lastCrashVesselId = vesselId;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning("[Telemachus] crash capture failed: " + e.Message);
+            }
+        }
+
+        private static void AppendPart(Dictionary<string, object> snap, Part origin, EventReport report)
+        {
+            if (snap == null || origin == null) return;
+            if (!snap.TryGetValue("partsLost", out var raw)) return;
+            if (raw is not List<Dictionary<string, object>> list) return;
+            list.Add(new Dictionary<string, object>
+            {
+                ["partName"] = origin.partInfo?.name ?? origin.name ?? string.Empty,
+                ["partTitle"] = origin.partInfo?.title ?? string.Empty,
+                ["partId"] = origin.flightID,
+                ["msg"] = report.msg ?? string.Empty,
+            });
+        }
+
+        private static List<string> ListCrewAboard(Vessel vessel)
+        {
+            var result = new List<string>();
+            if (vessel == null) return result;
+            try
+            {
+                var crew = vessel.GetVesselCrew();
+                if (crew == null) return result;
+                foreach (var member in crew)
+                {
+                    if (member?.name != null) result.Add(member.name);
+                }
+            }
+            catch (Exception)
+            {
+                // Protected vessels in odd states can throw — treat as no crew.
+            }
+            return result;
+        }
+
+        [TelemetryAPI("crash.hasRecent",
+            "Whether a crash snapshot has been captured this session.",
+            AlwaysEvaluable = true,
+            Category = "crash",
+            ReturnType = "bool")]
+        object HasRecent(DataSources ds) => _lastCrash != null;
+
+        [TelemetryAPI("crash.lastCrash",
+            "Most recent crash snapshot. Fields: vesselName, vesselId, " +
+            "body, situation, latitude, longitude, altitude, ut, what " +
+            "(what was hit), msg, eventKind (Crash/CrashSplashdown), " +
+            "partsLost (list of {partName, partTitle, partId, msg}), " +
+            "crewAboard (names), kerbalsKilled (names). Per-vessel events " +
+            "within 5 seconds coalesce into one snapshot; later vessels " +
+            "or later windows start fresh. Persists across scene changes; " +
+            "cleared on KSP restart.",
+            AlwaysEvaluable = true,
+            Plotable = false,
+            Category = "crash",
+            ReturnType = "object")]
+        object LastCrash(DataSources ds) => _lastCrash;
+    }
+
+    /// <summary>Deferred subscriber — instance handlers required because EvtDelegate ctor reads Target.GetType().</summary>
+    [KSPAddon(KSPAddon.Startup.MainMenu, true)]
+    public class CrashDataSubscriber : MonoBehaviour
+    {
+        private static bool _subscribed;
+
+        private float _crewSampleAccumulator;
+        private const float CrewSampleIntervalSeconds = 0.5f;
+        private readonly List<string> _crewScratch = new List<string>();
+
+        private void Awake()
+        {
+            DontDestroyOnLoad(this);
+            if (_subscribed) return;
+            try
+            {
+                GameEvents.onCrash.Add(HandleCrash);
+                GameEvents.onCrashSplashdown.Add(HandleCrashSplashdown);
+                GameEvents.onCrewKilled.Add(HandleCrewKilled);
+                _subscribed = true;
+                Debug.Log("[Telemachus] CrashDataSubscriber: subscribed to onCrash/onCrashSplashdown/onCrewKilled");
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning(
+                    "[Telemachus] CrashDataSubscriber: subscription failed; " +
+                    "crash.lastCrash will stay empty this session: " + e.Message);
+            }
+        }
+
+        private void Update()
+        {
+            _crewSampleAccumulator += Time.unscaledDeltaTime;
+            if (_crewSampleAccumulator < CrewSampleIntervalSeconds) return;
+            _crewSampleAccumulator = 0f;
+            try
+            {
+                var vessel = FlightGlobals.ActiveVessel;
+                if (vessel == null) return;
+                _crewScratch.Clear();
+                var crew = vessel.GetVesselCrew();
+                if (crew != null)
+                {
+                    foreach (var member in crew)
+                    {
+                        if (member?.name != null) _crewScratch.Add(member.name);
+                    }
+                }
+                CrashDataHandler.RefreshLiveCrew(vessel.id.ToString(), _crewScratch);
+            }
+            catch (Exception)
+            {
+                // Scene transitions can throw inside GetVesselCrew() — keep the last-known sample.
+            }
+        }
+
+        private void HandleCrash(EventReport r) => CrashDataHandler.OnCrash(r);
+        private void HandleCrashSplashdown(EventReport r) => CrashDataHandler.OnCrashSplashdown(r);
+        private void HandleCrewKilled(EventReport r) => CrashDataHandler.OnCrewKilled(r);
+    }
+}

--- a/Telemachus/src/CrashDataHandler.cs
+++ b/Telemachus/src/CrashDataHandler.cs
@@ -301,17 +301,19 @@ namespace Telemachus
         object HasRecent(DataSources ds) => _lastCrash != null;
 
         [TelemetryAPI("crash.lastCrash",
-            "Most recent notable-vessel crash snapshot. Debris, flags, and " +
-            "unclassified objects are excluded — they don't overwrite the " +
-            "last real crash. Fields: vesselName, vesselType " +
-            "(KSP VesselType e.g. Ship/Probe/SpaceObject), vesselId, " +
-            "body, situation, latitude, longitude, altitude, ut, what " +
-            "(what was hit), msg, eventKind (Crash/CrashSplashdown), " +
-            "partsLost (list of {partName, partTitle, partId, msg}), " +
-            "crewAboard (names), kerbalsKilled (names). Per-vessel events " +
-            "within 5 seconds coalesce into one snapshot; later vessels " +
-            "or later windows start fresh. Persists across scene changes; " +
-            "cleared on KSP restart.",
+            "Most recent notable-vessel crash snapshot. Captures terrain " +
+            "(eventKind Crash), water (CrashSplashdown), and non-collision " +
+            "losses such as re-entry burn-up or structural break-up " +
+            "(Destroyed). Debris, flags, and unclassified vessels are " +
+            "excluded so they don't overwrite the last real crash. Fields: " +
+            "vesselName, vesselType (KSP VesselType e.g. Ship/Probe/" +
+            "SpaceObject), vesselId, body, situation, latitude, longitude, " +
+            "altitude, ut, what (what was hit; empty for Destroyed), msg, " +
+            "eventKind (Crash/CrashSplashdown/Destroyed), partsLost (list " +
+            "of {partName, partTitle, partId, msg}), crewAboard (names), " +
+            "kerbalsKilled (names), events (flight log), flightStats. " +
+            "Per-vessel collision events within 5 seconds coalesce into one " +
+            "snapshot. Persists across scene changes; cleared on KSP restart.",
             AlwaysEvaluable = true,
             Plotable = false,
             Category = "crash",

--- a/Telemachus/src/CrashDataHandler.cs
+++ b/Telemachus/src/CrashDataHandler.cs
@@ -13,6 +13,21 @@ namespace Telemachus
         private static double _lastCrashUT;
         private static string _lastCrashVesselId;
 
+        // Wall-clock (realtimeSinceStartup) of the last capture. Used ONLY to
+        // dedup the onCrash→onVesselWillDestroy pair of a single collision crash
+        // (they fire in the same frame). Game-UT can't be used for this: a
+        // revert resets it and reuses the vesselId, which made a separate later
+        // burn-up look "already captured". Wall-clock doesn't reset on revert.
+        private static float _lastCaptureRealtime = -999f;
+
+        // Suppression for the onVesselWillDestroy detector — set while a benign
+        // destruction is in progress (revert / recovery / scene change). All
+        // cleared when the next scene finishes loading, so a stuck flag can
+        // never make us miss a later real crash.
+        private static bool _reverting;
+        private static bool _recovering;
+        private static bool _sceneChanging;
+
         // onCrewKilled fires before onCrash — buffer kill names so they don't get lost when the snapshot is built.
         private static readonly List<string> _pendingKerbalsKilled = new List<string>();
 
@@ -28,6 +43,109 @@ namespace Telemachus
 
         internal static void OnCrash(EventReport report) => CaptureCrash(report, "Crash");
         internal static void OnCrashSplashdown(EventReport report) => CaptureCrash(report, "CrashSplashdown");
+
+        // ── Vessel-destroyed detector ───────────────────────────────────────
+        // Collision crashes fire onCrash/onCrashSplashdown (handled above).
+        // Non-collision deaths — re-entry burn-up, structural/aero failure —
+        // fire NEITHER, but every fatal outcome fires onVesselWillDestroy. We use
+        // it as the universal "the mission ended by mishap" signal, scoped to the
+        // active vessel and gated against benign destroys (revert / recovery /
+        // scene change). A collision crash already captured by onCrash in the
+        // same frame is deduped, so it is not double-recorded.
+        internal static void OnVesselWillDestroy(Vessel v)
+        {
+            try
+            {
+                if (!IsRecordableMishap(v)) return;
+                CaptureVesselDestroyed(v);
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning("[Telemachus] vessel-destroy capture failed: " + e.Message);
+            }
+        }
+
+        private static bool IsRecordableMishap(Vessel v)
+        {
+            if (v == null || v != FlightGlobals.ActiveVessel) return false;
+            if (_reverting || _recovering || _sceneChanging) return false;
+            if (v.situation == Vessel.Situations.PRELAUNCH) return false;
+            var vType = v.vesselType;
+            if (vType == VesselType.Debris || vType == VesselType.Flag || vType == VesselType.Unknown)
+                return false;
+            // Dedup the same collision crash onCrash just captured — those fire in
+            // the same frame, so use WALL-CLOCK, not game-UT (a revert resets game-
+            // UT while reusing the vesselId, which would falsely match a separate
+            // later crash). A burn-up minutes later won't fall in this window.
+            if (_lastCrash != null && _lastCrashVesselId == v.id.ToString()
+                && Time.realtimeSinceStartup - _lastCaptureRealtime < 2f)
+                return false;
+            return true;
+        }
+
+        private static void CaptureVesselDestroyed(Vessel v)
+        {
+            double ut = Planetarium.GetUniversalTime();
+            var partsLost = new List<Dictionary<string, object>>();
+            if (v.parts != null)
+            {
+                foreach (var p in v.parts)
+                {
+                    if (p == null) continue;
+                    partsLost.Add(new Dictionary<string, object>
+                    {
+                        ["partName"] = p.partInfo?.name ?? p.name ?? string.Empty,
+                        ["partTitle"] = p.partInfo?.title ?? string.Empty,
+                        ["partId"] = p.flightID,
+                        ["msg"] = string.Empty,
+                    });
+                }
+            }
+            var crewAboard = _lastKnownCrew != null && _lastKnownCrew.Count > 0
+                ? new List<string>(_lastKnownCrew)
+                : ListCrewAboard(v);
+            var kerbalsKilled = new List<string>(_pendingKerbalsKilled);
+            _pendingKerbalsKilled.Clear();
+            var snap = new Dictionary<string, object>
+            {
+                // "Destroyed" = non-collision loss (burn-up / structural). The
+                // banner shows VESSEL DESTROYED for any eventKind; this just
+                // distinguishes it from terrain (Crash) / water (CrashSplashdown).
+                ["eventKind"] = "Destroyed",
+                ["vesselName"] = v.vesselName ?? string.Empty,
+                ["vesselType"] = v.vesselType.ToString(),
+                ["vesselId"] = v.id.ToString(),
+                ["body"] = v.mainBody?.bodyName ?? string.Empty,
+                ["situation"] = v.situation.ToString(),
+                ["latitude"] = R4(v.latitude),
+                ["longitude"] = R4(v.longitude),
+                ["altitude"] = R4(v.altitude),
+                ["ut"] = R4(ut),
+                ["what"] = string.Empty,
+                ["msg"] = string.Empty,
+                ["partsLost"] = partsLost,
+                ["crewAboard"] = crewAboard,
+                ["kerbalsKilled"] = kerbalsKilled,
+                ["events"] = FlightLoggerSnapshot.CaptureEvents(),
+                ["flightStats"] = FlightLoggerSnapshot.Capture(),
+            };
+            _lastCrash = snap;
+            _lastCrashUT = ut;
+            _lastCrashVesselId = v.id.ToString();
+            _lastCaptureRealtime = Time.realtimeSinceStartup;
+        }
+
+        // Suppression bookkeeping — benign destroys must not register as crashes.
+        internal static void NoteRevert() => _reverting = true;
+        internal static void NoteRecoveryRequested() => _recovering = true;
+        internal static void NoteVesselRecovered() => _recovering = false;
+        internal static void NoteSceneLoad() => _sceneChanging = true;
+        internal static void NoteLevelLoaded()
+        {
+            _reverting = false;
+            _recovering = false;
+            _sceneChanging = false;
+        }
 
         internal static void OnCrewKilled(EventReport report)
         {
@@ -77,6 +195,22 @@ namespace Telemachus
                 var vesselId = vessel?.id.ToString() ?? string.Empty;
                 var ut = Planetarium.GetUniversalTime();
 
+                // crash.lastCrash is a single-slot "last notable crash" record,
+                // not a raw impact feed. Spent debris (decoupled boosters/
+                // stages), planted flags, and unclassified objects aren't a
+                // vessel the operator is flying — recording them would clobber
+                // the slot and lose the real crash. Drop them at the source so
+                // every consumer (banner, flight-history annotation, reconnect
+                // replay) sees the right value. SpaceObject/asteroids are
+                // pilotable, so they stay.
+                var vType = vessel?.vesselType;
+                if (vType == VesselType.Debris
+                    || vType == VesselType.Flag
+                    || vType == VesselType.Unknown)
+                {
+                    return;
+                }
+
                 // Same vessel within window → append to existing snapshot.
                 if (_lastCrash != null
                     && _lastCrashVesselId == vesselId
@@ -84,6 +218,7 @@ namespace Telemachus
                 {
                     AppendPart(_lastCrash, origin, report);
                     _lastCrashUT = ut;
+                    _lastCaptureRealtime = Time.realtimeSinceStartup;
                     return;
                 }
 
@@ -96,6 +231,7 @@ namespace Telemachus
                 {
                     ["eventKind"] = eventKind,
                     ["vesselName"] = vessel?.vesselName ?? report.sender ?? string.Empty,
+                    ["vesselType"] = vessel?.vesselType.ToString() ?? string.Empty,
                     ["vesselId"] = vesselId,
                     ["body"] = vessel?.mainBody?.bodyName ?? string.Empty,
                     ["situation"] = vessel?.situation.ToString() ?? string.Empty,
@@ -115,6 +251,7 @@ namespace Telemachus
                 _lastCrash = snap;
                 _lastCrashUT = ut;
                 _lastCrashVesselId = vesselId;
+                _lastCaptureRealtime = Time.realtimeSinceStartup;
             }
             catch (Exception e)
             {
@@ -164,7 +301,10 @@ namespace Telemachus
         object HasRecent(DataSources ds) => _lastCrash != null;
 
         [TelemetryAPI("crash.lastCrash",
-            "Most recent crash snapshot. Fields: vesselName, vesselId, " +
+            "Most recent notable-vessel crash snapshot. Debris, flags, and " +
+            "unclassified objects are excluded — they don't overwrite the " +
+            "last real crash. Fields: vesselName, vesselType " +
+            "(KSP VesselType e.g. Ship/Probe/SpaceObject), vesselId, " +
             "body, situation, latitude, longitude, altitude, ut, what " +
             "(what was hit), msg, eventKind (Crash/CrashSplashdown), " +
             "partsLost (list of {partName, partTitle, partId, msg}), " +
@@ -198,8 +338,20 @@ namespace Telemachus
                 GameEvents.onCrash.Add(HandleCrash);
                 GameEvents.onCrashSplashdown.Add(HandleCrashSplashdown);
                 GameEvents.onCrewKilled.Add(HandleCrewKilled);
+
+                // Universal mishap signal for non-collision deaths (burn-up,
+                // structural) that fire no onCrash. Gated against benign
+                // destroys by the revert/recovery/scene-load subscriptions.
+                GameEvents.onVesselWillDestroy.Add(HandleVesselWillDestroy);
+                GameEvents.OnRevertToLaunchFlightState.Add(HandleRevertLaunch);
+                GameEvents.OnRevertToPrelaunchFlightState.Add(HandleRevertPrelaunch);
+                GameEvents.OnVesselRecoveryRequested.Add(HandleRecoveryRequested);
+                GameEvents.onVesselRecovered.Add(HandleVesselRecovered);
+                GameEvents.onGameSceneLoadRequested.Add(HandleSceneLoadRequested);
+                GameEvents.onLevelWasLoaded.Add(HandleLevelLoaded);
+
                 _subscribed = true;
-                Debug.Log("[Telemachus] CrashDataSubscriber: subscribed to onCrash/onCrashSplashdown/onCrewKilled");
+                Debug.Log("[Telemachus] CrashDataSubscriber: subscribed to onCrash/onCrashSplashdown/onCrewKilled + onVesselWillDestroy (+ suppression)");
             }
             catch (Exception e)
             {
@@ -238,5 +390,14 @@ namespace Telemachus
         private void HandleCrash(EventReport r) => CrashDataHandler.OnCrash(r);
         private void HandleCrashSplashdown(EventReport r) => CrashDataHandler.OnCrashSplashdown(r);
         private void HandleCrewKilled(EventReport r) => CrashDataHandler.OnCrewKilled(r);
+
+        // Instance handlers (EvtDelegate needs a real Target.GetType()).
+        private void HandleVesselWillDestroy(Vessel v) => CrashDataHandler.OnVesselWillDestroy(v);
+        private void HandleRevertLaunch(FlightState s) => CrashDataHandler.NoteRevert();
+        private void HandleRevertPrelaunch(FlightState s) => CrashDataHandler.NoteRevert();
+        private void HandleRecoveryRequested(Vessel v) => CrashDataHandler.NoteRecoveryRequested();
+        private void HandleVesselRecovered(ProtoVessel pv, bool quick) => CrashDataHandler.NoteVesselRecovered();
+        private void HandleSceneLoadRequested(GameScenes s) => CrashDataHandler.NoteSceneLoad();
+        private void HandleLevelLoaded(GameScenes s) => CrashDataHandler.NoteLevelLoaded();
     }
 }

--- a/Telemachus/src/FlightLogHandler.cs
+++ b/Telemachus/src/FlightLogHandler.cs
@@ -1,0 +1,32 @@
+namespace Telemachus
+{
+    /// <summary>Read-access to KSP's FlightLogger — same data the in-game Flight Results dialog renders. AlwaysEvaluable because the snapshot helper degrades gracefully outside flight.</summary>
+    public class FlightLogHandler : DataLinkHandler
+    {
+        public FlightLogHandler(FormatterProvider formatters)
+            : base(formatters) { }
+
+        [TelemetryAPI("flight.events",
+            "Pre-formatted event timeline from KSP's FlightLogger — the same " +
+            "strings the in-game Flight Results dialog renders in the Flight " +
+            "Events panel. Empty list outside flight.",
+            AlwaysEvaluable = true,
+            Plotable = false,
+            Category = "flight",
+            ReturnType = "object")]
+        object Events(DataSources ds) => FlightLoggerSnapshot.CaptureEvents();
+
+        [TelemetryAPI("flight.achievements",
+            "Running mission stats from KSP's FlightLogger — same data the " +
+            "Flight Results dialog renders in the Flight Achievements panel. " +
+            "Fields: missionTime, liftOff, highestAltitude, highestSpeed, " +
+            "highestSpeedOverLand, groundDistance, totalDistance, highestGee, " +
+            "partsLost (count), kerbalsKilled (count), missionEnd, " +
+            "flightEndMode. Returns null outside flight.",
+            AlwaysEvaluable = true,
+            Plotable = false,
+            Category = "flight",
+            ReturnType = "object")]
+        object Achievements(DataSources ds) => FlightLoggerSnapshot.Capture();
+    }
+}

--- a/Telemachus/src/FlightLoggerSnapshot.cs
+++ b/Telemachus/src/FlightLoggerSnapshot.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+
+namespace Telemachus
+{
+    /// <summary>Shared snapshot helper for FlightLogger — most fields are private instance fields, accessed via cached reflection.</summary>
+    public static class FlightLoggerSnapshot
+    {
+        private static bool _reflectionResolved;
+        private static FieldInfo _highestAltitude;
+        private static FieldInfo _groundDistance;
+        private static FieldInfo _totalDistance;
+        private static FieldInfo _highestGee;
+        private static FieldInfo _highestSpeed;
+        private static FieldInfo _highestSpeedOverLand;
+        private static FieldInfo _liftOff;
+        private static FieldInfo _missionEnd;
+        private static FieldInfo _partsLost;
+        private static FieldInfo _kerbalsKilled;
+        private static FieldInfo _flightEndMode;
+
+        private static void EnsureReflection()
+        {
+            if (_reflectionResolved) return;
+            var t = typeof(FlightLogger);
+            const BindingFlags bf = BindingFlags.NonPublic | BindingFlags.Instance;
+            _highestAltitude = t.GetField("highestAltitude", bf);
+            _groundDistance = t.GetField("groundDistance", bf);
+            _totalDistance = t.GetField("totalDistance", bf);
+            _highestGee = t.GetField("highestGee", bf);
+            _highestSpeed = t.GetField("highestSpeed", bf);
+            _highestSpeedOverLand = t.GetField("highestSpeedOverLand", bf);
+            _liftOff = t.GetField("liftOff", bf);
+            _missionEnd = t.GetField("missionEnd", bf);
+            _partsLost = t.GetField("partsLost", bf);
+            _kerbalsKilled = t.GetField("kerbalsKilled", bf);
+            _flightEndMode = t.GetField("flightEndMode", bf);
+            _reflectionResolved = true;
+        }
+
+        private static double R4(double v) => Math.Round(v, 4);
+
+        private static T ReadField<T>(FieldInfo f, FlightLogger logger, T fallback)
+        {
+            if (f == null || logger == null) return fallback;
+            try
+            {
+                var v = f.GetValue(logger);
+                if (v is T typed) return typed;
+                return fallback;
+            }
+            catch (Exception)
+            {
+                return fallback;
+            }
+        }
+
+        /// <summary>Snapshot current FlightLogger state — returns null when FlightLogger.fetch isn't available (no flight scene).</summary>
+        public static Dictionary<string, object> Capture()
+        {
+            try
+            {
+                var logger = FlightLogger.fetch;
+                if (logger == null) return null;
+                EnsureReflection();
+                return new Dictionary<string, object>
+                {
+                    ["missionTime"] = R4(FlightLogger.met),
+                    ["liftOff"] = FlightLogger.LiftOff,
+                    ["highestAltitude"] = R4(ReadField(_highestAltitude, logger, 0.0)),
+                    ["highestSpeed"] = R4(ReadField(_highestSpeed, logger, 0.0)),
+                    ["highestSpeedOverLand"] = R4(ReadField(_highestSpeedOverLand, logger, 0.0)),
+                    ["groundDistance"] = R4(ReadField(_groundDistance, logger, 0.0)),
+                    ["totalDistance"] = R4(ReadField(_totalDistance, logger, 0.0)),
+                    ["highestGee"] = R4(ReadField(_highestGee, logger, 0.0)),
+                    ["partsLost"] = ReadField(_partsLost, logger, 0),
+                    ["kerbalsKilled"] = ReadField(_kerbalsKilled, logger, 0),
+                    ["missionEnd"] = ReadField(_missionEnd, logger, false),
+                    ["flightEndMode"] =
+                        ReadField<object>(_flightEndMode, logger, null)?.ToString() ?? string.Empty,
+                };
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning("[Telemachus] FlightLoggerSnapshot.Capture failed: " + e.Message);
+                return null;
+            }
+        }
+
+        /// <summary>Copy of FlightLogger.eventLog so later mutations don't change captured snapshots.</summary>
+        public static List<string> CaptureEvents()
+        {
+            try
+            {
+                var log = FlightLogger.eventLog;
+                if (log == null) return new List<string>();
+                return new List<string>(log);
+            }
+            catch (Exception)
+            {
+                return new List<string>();
+            }
+        }
+    }
+}

--- a/Telemachus/src/KSPAPIBase.cs
+++ b/Telemachus/src/KSPAPIBase.cs
@@ -26,6 +26,9 @@ namespace Telemachus
             APIHandlers.Add(new ScienceCareerDataLinkHandler(formatters));
             APIHandlers.Add(new TimeWarpDataLinkHandler(formatters));
             APIHandlers.Add(new TargetDataLinkHandler(formatters));
+            APIHandlers.Add(new RecoveryDialogHandler(formatters));
+            APIHandlers.Add(new CrashDataHandler(formatters));
+            APIHandlers.Add(new FlightLogHandler(formatters));
 
             APIHandlers.Add(new CompoundDataLinkHandler(
                 new List<DataLinkHandler> {

--- a/Telemachus/src/RecoveryDialogHandler.cs
+++ b/Telemachus/src/RecoveryDialogHandler.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using KSP.UI.Screens;
+using UnityEngine;
+
+namespace Telemachus
+{
+    /// <summary>Mission-summary snapshot captured via GameEvents — subscription deferred to RecoveryDialogSubscriber because subscribing from KSPAPI..ctor throws NRE in EvtDelegate.</summary>
+    public class RecoveryDialogHandler : DataLinkHandler
+    {
+        private static FieldInfo _scienceField;
+        private static FieldInfo _partField;
+        private static FieldInfo _resourceField;
+        private static FieldInfo _crewField;
+        private static bool _reflectionResolved;
+
+        private static Dictionary<string, object> _lastSummary;
+
+        // Stashed by onVesselRecovered for the 1-param fallback path (spawn doesn't pass ProtoVessel).
+        private static string _pendingVesselName;
+
+        public RecoveryDialogHandler(FormatterProvider formatters)
+            : base(formatters) { }
+
+        internal static void OnRecoveryProcessingComplete(
+            ProtoVessel pv, MissionRecoveryDialog dialog, float progress)
+        {
+            // Progress fires throughout the tally animation; snapshot only at 100%.
+            if (progress < 0.999f) return;
+            if (dialog == null) return;
+            _pendingVesselName = pv?.vesselName ?? string.Empty;
+            CaptureSnapshot(dialog);
+        }
+
+        internal static void OnVesselRecovered(ProtoVessel pv, bool quick)
+        {
+            _pendingVesselName = pv?.vesselName ?? string.Empty;
+        }
+
+        internal static void OnDialogSpawn(MissionRecoveryDialog dialog)
+        {
+            CaptureSnapshot(dialog);
+        }
+
+        private static double R4(double v)
+        {
+            return Math.Round(v, 4);
+        }
+
+        private static double R4(float v) => R4((double)v);
+
+        private static void EnsureReflection()
+        {
+            if (_reflectionResolved) return;
+            var t = typeof(MissionRecoveryDialog);
+            const BindingFlags bf = BindingFlags.NonPublic | BindingFlags.Instance;
+            _scienceField = t.GetField("scienceWidgets", bf);
+            _partField = t.GetField("partWidgets", bf);
+            _resourceField = t.GetField("resourceWidgets", bf);
+            _crewField = t.GetField("crewWidgets", bf);
+            _reflectionResolved = true;
+        }
+
+        private static void CaptureSnapshot(MissionRecoveryDialog dialog)
+        {
+            if (dialog == null) return;
+
+            try
+            {
+                EnsureReflection();
+                var snap = new Dictionary<string, object>
+                {
+                    ["vesselName"] = _pendingVesselName ?? string.Empty,
+                    ["recoveryLocation"] = dialog.recoveryLocation ?? string.Empty,
+                    ["recoveryFactor"] = dialog.recoveryFactor ?? string.Empty,
+                    ["scienceEarned"] = R4(dialog.scienceEarned),
+                    ["beforeMissionScience"] = R4(dialog.beforeMissionScience),
+                    ["totalScience"] = R4(dialog.totalScience),
+                    ["scienceModifier"] = dialog.ScienceModifier ?? string.Empty,
+                    ["fundsEarned"] = R4(dialog.fundsEarned),
+                    ["beforeMissionFunds"] = R4(dialog.beforeMissionFunds),
+                    ["totalFunds"] = R4(dialog.totalFunds),
+                    ["fundsModifier"] = dialog.FundsModifier ?? string.Empty,
+                    ["reputationEarned"] = R4(dialog.reputationEarned),
+                    ["beforeMissionReputation"] = R4(dialog.beforeMissionReputation),
+                    ["totalReputation"] = R4(dialog.totalReputation),
+                    ["repModifier"] = dialog.RepModifier ?? string.Empty,
+                    ["displayReputation"] = dialog.displayReputation,
+                    ["scienceModeAvailable"] = dialog.ScienceModeAvailable,
+                    ["partsModeAvailable"] = dialog.PartsModeAvailable,
+                    ["crewModeAvailable"] = dialog.CrewModeAvailable,
+                    ["capturedAtUT"] = Planetarium.GetUniversalTime(),
+                    ["scienceBreakdown"] = ExtractScience(dialog),
+                    ["partBreakdown"] = ExtractParts(dialog),
+                    ["resourceBreakdown"] = ExtractResources(dialog),
+                    ["crewBreakdown"] = ExtractCrew(dialog),
+                    ["events"] = FlightLoggerSnapshot.CaptureEvents(),
+                    ["flightStats"] = FlightLoggerSnapshot.Capture(),
+                };
+                _lastSummary = snap;
+                _pendingVesselName = null;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning(
+                    "[Telemachus] recovery snapshot capture failed: " + e.Message);
+            }
+        }
+
+        private static List<Dictionary<string, object>> ExtractScience(MissionRecoveryDialog dialog)
+        {
+            var result = new List<Dictionary<string, object>>();
+            var raw = _scienceField?.GetValue(dialog) as IEnumerable;
+            if (raw == null) return result;
+            foreach (var item in raw)
+            {
+                if (item is not KSP.UI.Screens.SpaceCenter.MissionSummaryDialog.ScienceSubjectWidget w)
+                    continue;
+                result.Add(new Dictionary<string, object>
+                {
+                    ["subjectId"] = w.subject?.id ?? string.Empty,
+                    ["subjectTitle"] = w.subject?.title ?? string.Empty,
+                    ["dataGathered"] = R4(w.dataGathered),
+                    ["scienceAmount"] = R4(w.scienceAmount),
+                });
+            }
+            return result;
+        }
+
+        private static List<Dictionary<string, object>> ExtractParts(MissionRecoveryDialog dialog)
+        {
+            var result = new List<Dictionary<string, object>>();
+            var raw = _partField?.GetValue(dialog) as IEnumerable;
+            if (raw == null) return result;
+            foreach (var item in raw)
+            {
+                if (item is not KSP.UI.Screens.SpaceCenter.MissionSummaryDialog.PartWidget w)
+                    continue;
+                result.Add(new Dictionary<string, object>
+                {
+                    ["partName"] = w.partInfo?.name ?? string.Empty,
+                    ["partTitle"] = w.partInfo?.title ?? string.Empty,
+                    ["count"] = w.count,
+                    ["partValue"] = R4(w.partValue),
+                    ["resourcesValue"] = R4(w.resourcesValue),
+                    ["totalValue"] = R4(w.totalValue),
+                });
+            }
+            return result;
+        }
+
+        private static List<Dictionary<string, object>> ExtractResources(MissionRecoveryDialog dialog)
+        {
+            var result = new List<Dictionary<string, object>>();
+            var raw = _resourceField?.GetValue(dialog) as IEnumerable;
+            if (raw == null) return result;
+            foreach (var item in raw)
+            {
+                if (item is not KSP.UI.Screens.SpaceCenter.MissionSummaryDialog.ResourceWidget w)
+                    continue;
+                result.Add(new Dictionary<string, object>
+                {
+                    ["resourceName"] = w.rscDef?.name ?? string.Empty,
+                    ["amount"] = R4(w.amount),
+                    ["unitValue"] = R4(w.unitValue),
+                    ["totalValue"] = R4(w.totalValue),
+                });
+            }
+            return result;
+        }
+
+        private static List<Dictionary<string, object>> ExtractCrew(MissionRecoveryDialog dialog)
+        {
+            var result = new List<Dictionary<string, object>>();
+            var raw = _crewField?.GetValue(dialog) as IEnumerable;
+            if (raw == null) return result;
+            foreach (var item in raw)
+            {
+                if (item is not KSP.UI.Screens.SpaceCenter.MissionSummaryDialog.CrewWidget w)
+                    continue;
+                result.Add(new Dictionary<string, object>
+                {
+                    ["name"] = w.crew?.name ?? string.Empty,
+                    ["trait"] = w.crew?.trait ?? string.Empty,
+                    ["isTourist"] = w.isTourist,
+                    ["xpGained"] = R4(w.xpGained),
+                    ["levelsGained"] = w.levelsGained,
+                    ["newLevel"] = w.newLevel,
+                });
+            }
+            return result;
+        }
+
+        [TelemetryAPI("recovery.hasRecent",
+            "Whether a mission-summary snapshot has been captured this " +
+            "session (true after the first vessel is recovered).",
+            AlwaysEvaluable = true,
+            Category = "recovery",
+            ReturnType = "bool")]
+        object HasRecent(DataSources ds) => _lastSummary != null;
+
+        [TelemetryAPI("recovery.lastSummary",
+            "Most recent mission-summary snapshot. Includes vessel name, " +
+            "recovery location and factor, science/funds/reputation " +
+            "totals + earned + modifiers, and per-experiment, per-part, " +
+            "per-resource, per-crew breakdowns. Captures automatically " +
+            "when KSP completes recovery processing (no dialog dismissal " +
+            "needed). Persists across scene changes; cleared on KSP " +
+            "restart.",
+            AlwaysEvaluable = true,
+            Plotable = false,
+            Category = "recovery",
+            ReturnType = "object")]
+        object LastSummary(DataSources ds) => _lastSummary;
+    }
+
+    /// <summary>Deferred subscriber — handlers must be instance methods because EvtDelegate ctor reads Target.GetType() and rejects static delegates.</summary>
+    [KSPAddon(KSPAddon.Startup.MainMenu, true)]
+    public class RecoveryDialogSubscriber : MonoBehaviour
+    {
+        private static bool _subscribed;
+
+        private void Awake()
+        {
+            DontDestroyOnLoad(this);
+            if (_subscribed) return;
+
+            try
+            {
+                GameEvents.onVesselRecoveryProcessingComplete.Add(HandleProcessingComplete);
+                _subscribed = true;
+                Debug.Log("[Telemachus] RecoveryDialogSubscriber: subscribed to onVesselRecoveryProcessingComplete");
+                return;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning(
+                    "[Telemachus] RecoveryDialogSubscriber: 3-param event subscription failed, " +
+                    "falling back to spawn+recovered: " + e.Message);
+            }
+
+            try
+            {
+                GameEvents.onVesselRecovered.Add(HandleVesselRecovered);
+                GameEvents.onGUIRecoveryDialogSpawn.Add(HandleDialogSpawn);
+                _subscribed = true;
+                Debug.Log("[Telemachus] RecoveryDialogSubscriber: subscribed to spawn+recovered fallback");
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning(
+                    "[Telemachus] RecoveryDialogSubscriber: fallback subscription failed; " +
+                    "recovery.lastSummary will stay empty this session: " + e.Message);
+            }
+        }
+
+        private void HandleProcessingComplete(ProtoVessel pv, MissionRecoveryDialog dialog, float progress)
+        {
+            RecoveryDialogHandler.OnRecoveryProcessingComplete(pv, dialog, progress);
+        }
+
+        private void HandleVesselRecovered(ProtoVessel pv, bool quick)
+        {
+            RecoveryDialogHandler.OnVesselRecovered(pv, quick);
+        }
+
+        private void HandleDialogSpawn(MissionRecoveryDialog dialog)
+        {
+            RecoveryDialogHandler.OnDialogSpawn(dialog);
+        }
+    }
+}

--- a/docs/api-schema.json
+++ b/docs/api-schema.json
@@ -39,8 +39,7 @@
     "alwaysEvaluable": true,
     "category": "system",
     "returnType": "object",
-    "declaringClass": "APIDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/SystemHandlers.cs"
+    "declaringClass": "APIDataLinkHandler"
   },
   {
     "key": "a.physicsMode",
@@ -51,8 +50,7 @@
     "alwaysEvaluable": true,
     "category": "system",
     "returnType": "string",
-    "declaringClass": "APIDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/SystemHandlers.cs"
+    "declaringClass": "APIDataLinkHandler"
   },
   {
     "key": "a.schema",
@@ -63,8 +61,7 @@
     "alwaysEvaluable": true,
     "category": "system",
     "returnType": "object",
-    "declaringClass": "APIDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/SystemHandlers.cs"
+    "declaringClass": "APIDataLinkHandler"
   },
   {
     "key": "a.version",
@@ -75,8 +72,7 @@
     "alwaysEvaluable": true,
     "category": "system",
     "returnType": "string",
-    "declaringClass": "APIDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/SystemHandlers.cs"
+    "declaringClass": "APIDataLinkHandler"
   },
   {
     "key": "alarm.count",
@@ -87,8 +83,7 @@
     "alwaysEvaluable": false,
     "category": "alarm",
     "returnType": "int",
-    "declaringClass": "AlarmClockDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AlarmClockHandlers.cs"
+    "declaringClass": "AlarmClockDataLinkHandler"
   },
   {
     "key": "alarm.list",
@@ -100,8 +95,7 @@
     "category": "alarm",
     "returnType": "object",
     "formatter": "AlarmList",
-    "declaringClass": "AlarmClockDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AlarmClockHandlers.cs"
+    "declaringClass": "AlarmClockDataLinkHandler"
   },
   {
     "key": "alarm.nextAlarm",
@@ -113,8 +107,7 @@
     "category": "alarm",
     "returnType": "object",
     "formatter": "Alarm",
-    "declaringClass": "AlarmClockDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AlarmClockHandlers.cs"
+    "declaringClass": "AlarmClockDataLinkHandler"
   },
   {
     "key": "alarm.timeToNext",
@@ -125,8 +118,7 @@
     "alwaysEvaluable": false,
     "category": "alarm",
     "returnType": "double",
-    "declaringClass": "AlarmClockDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AlarmClockHandlers.cs"
+    "declaringClass": "AlarmClockDataLinkHandler"
   },
   {
     "key": "astg.active",
@@ -135,8 +127,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.activeTransfer",
@@ -145,8 +136,7 @@
     "plotable": false,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.available",
@@ -155,8 +145,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": true,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.createManeuver",
@@ -165,8 +154,7 @@
     "plotable": true,
     "isAction": true,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.errorCondition",
@@ -175,8 +163,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.hyperbolicOrbit",
@@ -185,8 +172,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.nextBurnCountdown",
@@ -195,8 +181,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.nextBurnTime",
@@ -205,8 +190,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.nextDeltaV",
@@ -215,8 +199,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.nextDestination",
@@ -225,8 +208,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.retrogradeOrbit",
@@ -235,8 +217,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.transfer",
@@ -245,8 +226,7 @@
     "plotable": false,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.transferCount",
@@ -255,8 +235,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.transfers",
@@ -265,8 +244,7 @@
     "plotable": false,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.warpToBurn",
@@ -275,8 +253,7 @@
     "plotable": true,
     "isAction": true,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "b.angularV",
@@ -288,8 +265,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.atmosphere",
@@ -301,8 +277,7 @@
     "category": "body",
     "returnType": "bool",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.atmosphereContainsOxygen",
@@ -314,8 +289,7 @@
     "category": "body",
     "returnType": "bool",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.description",
@@ -327,8 +301,7 @@
     "category": "body",
     "returnType": "string",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.geeASL",
@@ -340,8 +313,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.hillSphere",
@@ -353,8 +325,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.index",
@@ -366,8 +337,7 @@
     "category": "body",
     "returnType": "int",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.mass",
@@ -379,8 +349,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.maxAtmosphere",
@@ -392,8 +361,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.name",
@@ -405,8 +373,7 @@
     "category": "body",
     "returnType": "string",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.number",
@@ -417,8 +384,7 @@
     "alwaysEvaluable": false,
     "category": "body",
     "returnType": "int",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.ApA",
@@ -430,8 +396,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.argumentOfPeriapsis",
@@ -443,8 +408,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.eccentricity",
@@ -456,8 +420,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.gravParameter",
@@ -469,8 +432,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.inclination",
@@ -482,8 +444,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.lan",
@@ -495,8 +456,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.maae",
@@ -508,8 +468,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.PeA",
@@ -521,8 +480,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.period",
@@ -534,8 +492,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.phaseAngle",
@@ -547,8 +504,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.relativeVelocity",
@@ -560,8 +516,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.sma",
@@ -573,8 +528,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.timeOfPeriapsisPassage",
@@ -586,8 +540,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.timeToAp",
@@ -599,8 +552,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.timeToPe",
@@ -612,8 +564,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.timeToTransition1",
@@ -625,8 +576,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.timeToTransition2",
@@ -638,8 +588,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.trueAnomaly",
@@ -651,8 +600,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.truePositionAtUT",
@@ -665,8 +613,7 @@
     "returnType": "Vector3d",
     "params": "int bodyId, double UT",
     "formatter": "Vector3d",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.ocean",
@@ -678,8 +625,7 @@
     "category": "body",
     "returnType": "bool",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.orbitingBodies",
@@ -692,8 +638,7 @@
     "returnType": "string[]",
     "params": "int bodyId",
     "formatter": "StringArray",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.position",
@@ -706,8 +651,7 @@
     "returnType": "Vector3d",
     "params": "int bodyId",
     "formatter": "Vector3d",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.radius",
@@ -719,8 +663,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.referenceBody",
@@ -732,8 +675,7 @@
     "category": "body",
     "returnType": "string",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.rotates",
@@ -745,8 +687,7 @@
     "category": "body",
     "returnType": "bool",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.rotationAngle",
@@ -758,8 +699,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.rotationPeriod",
@@ -771,8 +711,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.soi",
@@ -784,8 +723,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.tidallyLocked",
@@ -797,8 +735,7 @@
     "category": "body",
     "returnType": "bool",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.timeWarpAltitudeLimits",
@@ -810,8 +747,7 @@
     "category": "body",
     "returnType": "object",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "career.funds",
@@ -822,8 +758,7 @@
     "alwaysEvaluable": true,
     "category": "career",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "career.mode",
@@ -834,8 +769,7 @@
     "alwaysEvaluable": true,
     "category": "career",
     "returnType": "string",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "career.reputation",
@@ -846,8 +780,7 @@
     "alwaysEvaluable": true,
     "category": "career",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "career.science",
@@ -858,8 +791,7 @@
     "alwaysEvaluable": true,
     "category": "career",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "comm.connected",
@@ -870,8 +802,7 @@
     "alwaysEvaluable": false,
     "category": "comms",
     "returnType": "bool",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "comm.controlState",
@@ -882,8 +813,7 @@
     "alwaysEvaluable": false,
     "category": "comms",
     "returnType": "int",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "comm.controlStateName",
@@ -894,8 +824,7 @@
     "alwaysEvaluable": false,
     "category": "comms",
     "returnType": "string",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "comm.signalDelay",
@@ -906,8 +835,7 @@
     "alwaysEvaluable": false,
     "category": "comms",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "comm.signalStrength",
@@ -918,8 +846,29 @@
     "alwaysEvaluable": false,
     "category": "comms",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
+  },
+  {
+    "key": "crash.hasRecent",
+    "description": "Whether a crash snapshot has been captured this session.",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "crash",
+    "returnType": "bool",
+    "declaringClass": "CrashDataHandler"
+  },
+  {
+    "key": "crash.lastCrash",
+    "description": "Most recent crash snapshot. Fields: vesselName, vesselId, body, situation, latitude, longitude, altitude, ut, what (what was hit), msg, eventKind (Crash/CrashSplashdown), partsLost (list of {partName, partTitle, partId, msg}), crewAboard (names), kerbalsKilled (names). Per-vessel events within 5 seconds coalesce into one snapshot; later vessels or later windows start fresh. Persists across scene changes; cleared on KSP restart.",
+    "units": "UNITLESS",
+    "plotable": false,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "crash",
+    "returnType": "object",
+    "declaringClass": "CrashDataHandler"
   },
   {
     "key": "dock.ax",
@@ -930,8 +879,7 @@
     "alwaysEvaluable": false,
     "category": "docking",
     "returnType": "double",
-    "declaringClass": "DockingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "DockingDataLinkHandler"
   },
   {
     "key": "dock.ay",
@@ -942,8 +890,7 @@
     "alwaysEvaluable": false,
     "category": "docking",
     "returnType": "double",
-    "declaringClass": "DockingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "DockingDataLinkHandler"
   },
   {
     "key": "dock.az",
@@ -954,8 +901,7 @@
     "alwaysEvaluable": false,
     "category": "docking",
     "returnType": "double",
-    "declaringClass": "DockingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "DockingDataLinkHandler"
   },
   {
     "key": "dock.x",
@@ -966,8 +912,7 @@
     "alwaysEvaluable": false,
     "category": "docking",
     "returnType": "double",
-    "declaringClass": "DockingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "DockingDataLinkHandler"
   },
   {
     "key": "dock.y",
@@ -978,8 +923,7 @@
     "alwaysEvaluable": false,
     "category": "docking",
     "returnType": "double",
-    "declaringClass": "DockingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "DockingDataLinkHandler"
   },
   {
     "key": "dv.ready",
@@ -990,8 +934,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "double",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stage",
@@ -1004,8 +947,7 @@
     "returnType": "object",
     "params": "int stage",
     "formatter": "DeltaVStageInfo",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageBurnTime",
@@ -1017,8 +959,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageCount",
@@ -1029,8 +970,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "int",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageDryMass",
@@ -1042,8 +982,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageDVActual",
@@ -1055,8 +994,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageDVASL",
@@ -1068,8 +1006,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageDVVac",
@@ -1081,8 +1018,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageEndMass",
@@ -1094,8 +1030,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageFuelMass",
@@ -1107,8 +1042,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageISPActual",
@@ -1120,8 +1054,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageISPASL",
@@ -1133,8 +1066,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageISPVac",
@@ -1146,8 +1078,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageMass",
@@ -1159,8 +1090,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stages",
@@ -1172,8 +1102,7 @@
     "category": "deltav",
     "returnType": "object",
     "formatter": "DeltaVStageInfoList",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageStartMass",
@@ -1185,8 +1114,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageThrustActual",
@@ -1198,8 +1126,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageThrustASL",
@@ -1211,8 +1138,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageThrustVac",
@@ -1224,8 +1150,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageTWRActual",
@@ -1237,8 +1162,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageTWRASL",
@@ -1250,8 +1174,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageTWRVac",
@@ -1263,8 +1186,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.totalBurnTime",
@@ -1275,8 +1197,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "double",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.totalDVActual",
@@ -1287,8 +1208,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "double",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.totalDVASL",
@@ -1299,8 +1219,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "double",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.totalDVVac",
@@ -1311,8 +1230,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "double",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "f.abort",
@@ -1453,8 +1371,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.killRot",
@@ -1465,8 +1382,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.light",
@@ -1487,8 +1403,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.pitchTrim",
@@ -1499,8 +1414,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.precisionControl",
@@ -1531,8 +1445,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.rollTrim",
@@ -1543,8 +1456,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.sas",
@@ -1565,8 +1477,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.sasMode",
@@ -1577,8 +1488,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "string",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.setPitchTrim",
@@ -1590,8 +1500,7 @@
     "category": "flight",
     "returnType": "int",
     "params": "float trim",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.setRollTrim",
@@ -1603,8 +1512,7 @@
     "category": "flight",
     "returnType": "int",
     "params": "float trim",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.setSASMode",
@@ -1616,8 +1524,7 @@
     "category": "flight",
     "returnType": "string",
     "params": "string mode",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.setThrottle",
@@ -1639,8 +1546,7 @@
     "category": "flight",
     "returnType": "int",
     "params": "float trim",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.stage",
@@ -1660,8 +1566,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.throttleDown",
@@ -1708,8 +1613,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.yawInput",
@@ -1720,8 +1624,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.yawTrim",
@@ -1732,8 +1635,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.yInput",
@@ -1744,8 +1646,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.zInput",
@@ -1756,8 +1657,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "far.aoa",
@@ -1769,8 +1669,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.available",
@@ -1782,8 +1681,7 @@
     "category": "far",
     "returnType": "bool",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.ballisticCoeff",
@@ -1795,8 +1693,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.decreaseFlaps",
@@ -1808,8 +1705,7 @@
     "category": "far",
     "returnType": "bool",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.dragCoeff",
@@ -1821,8 +1717,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.dynPres",
@@ -1834,8 +1729,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.flapSetting",
@@ -1847,8 +1741,7 @@
     "category": "far",
     "returnType": "int",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.increaseFlaps",
@@ -1860,8 +1753,7 @@
     "category": "far",
     "returnType": "bool",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.liftCoeff",
@@ -1873,8 +1765,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.refArea",
@@ -1886,8 +1777,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.setSpoilers",
@@ -1900,8 +1790,7 @@
     "returnType": "bool",
     "params": "bool active",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.sideslip",
@@ -1913,8 +1802,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.spoiler",
@@ -1926,8 +1814,7 @@
     "category": "far",
     "returnType": "bool",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.stallFrac",
@@ -1939,8 +1826,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.termVel",
@@ -1952,8 +1838,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.tsfc",
@@ -1965,8 +1850,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.voxelized",
@@ -1978,8 +1862,29 @@
     "category": "far",
     "returnType": "bool",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
+  },
+  {
+    "key": "flight.achievements",
+    "description": "Running mission stats from KSP's FlightLogger — same data the Flight Results dialog renders in the Flight Achievements panel. Fields: missionTime, liftOff, highestAltitude, highestSpeed, highestSpeedOverLand, groundDistance, totalDistance, highestGee, partsLost (count), kerbalsKilled (count), missionEnd, flightEndMode. Returns null outside flight.",
+    "units": "UNITLESS",
+    "plotable": false,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "flight",
+    "returnType": "object",
+    "declaringClass": "FlightLogHandler"
+  },
+  {
+    "key": "flight.events",
+    "description": "Pre-formatted event timeline from KSP's FlightLogger — the same strings the in-game Flight Results dialog renders in the Flight Events panel. Empty list outside flight.",
+    "units": "UNITLESS",
+    "plotable": false,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "flight",
+    "returnType": "object",
+    "declaringClass": "FlightLogHandler"
   },
   {
     "key": "kerbalism.available",
@@ -1991,8 +1896,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.breathable",
@@ -2004,8 +1908,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.co2Level",
@@ -2017,8 +1920,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.connection",
@@ -2030,8 +1932,7 @@
     "category": "kerbalism",
     "returnType": "object",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.connectionLinked",
@@ -2043,8 +1944,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.connectionRate",
@@ -2056,8 +1956,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.connectionTransmitting",
@@ -2069,8 +1968,7 @@
     "category": "kerbalism",
     "returnType": "int",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.crew",
@@ -2082,8 +1980,7 @@
     "category": "kerbalism",
     "returnType": "object",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.critical",
@@ -2095,8 +1992,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.drivesCapacity",
@@ -2108,8 +2004,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.drivesFreeSpace",
@@ -2121,8 +2016,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.envStormRadiation",
@@ -2134,8 +2028,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.envTempDiff",
@@ -2147,8 +2040,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.envTemperature",
@@ -2160,8 +2052,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.experimentRunning",
@@ -2173,8 +2064,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.features",
@@ -2186,8 +2076,7 @@
     "category": "kerbalism",
     "returnType": "object",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatComfort",
@@ -2199,8 +2088,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatLivingSpace",
@@ -2212,8 +2100,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatPressure",
@@ -2225,8 +2112,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatRadiation",
@@ -2238,8 +2124,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatSurface",
@@ -2251,8 +2136,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatVolume",
@@ -2264,8 +2148,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.inAtmosphere",
@@ -2277,8 +2160,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.innerBelt",
@@ -2290,8 +2172,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.magnetosphere",
@@ -2303,8 +2184,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.malfunction",
@@ -2316,8 +2196,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.outerBelt",
@@ -2329,8 +2208,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.radiation",
@@ -2342,8 +2220,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.radiationEnabled",
@@ -2355,8 +2232,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.radiationShielding",
@@ -2368,8 +2244,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.solarExposure",
@@ -2381,8 +2256,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarActivity",
@@ -2394,8 +2268,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarStormDuration",
@@ -2407,8 +2280,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarStormIncoming",
@@ -2420,8 +2292,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarStormInProgress",
@@ -2433,8 +2304,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarStormStartTime",
@@ -2446,8 +2316,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarStormState",
@@ -2459,8 +2328,7 @@
     "category": "kerbalism",
     "returnType": "int",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "land.bestSpeedAtImpact",
@@ -2471,8 +2339,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.predictedAlt",
@@ -2483,8 +2350,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.predictedLat",
@@ -2495,8 +2361,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.predictedLon",
@@ -2507,8 +2372,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.slopeAngle",
@@ -2519,8 +2383,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.speedAtImpact",
@@ -2531,8 +2394,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.suicideBurnCountdown",
@@ -2543,8 +2405,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.timeToImpact",
@@ -2555,8 +2416,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "m.mapIsEnabled",
@@ -2567,8 +2427,7 @@
     "alwaysEvaluable": false,
     "category": "map",
     "returnType": "bool",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "mj.available",
@@ -2580,8 +2439,7 @@
     "category": "mechjeb",
     "returnType": "bool",
     "requiresMod": "mechjeb",
-    "declaringClass": "MechJebDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/MechJebDataLinkHandler.cs"
+    "declaringClass": "MechJebDataLinkHandler"
   },
   {
     "key": "mj.node",
@@ -2764,8 +2622,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.heading2",
@@ -2776,8 +2633,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.pitch",
@@ -2788,8 +2644,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.pitch2",
@@ -2800,8 +2655,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawheading",
@@ -2812,8 +2666,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawheading2",
@@ -2824,8 +2677,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawpitch",
@@ -2836,8 +2688,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawpitch2",
@@ -2848,8 +2699,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawroll",
@@ -2860,8 +2710,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawroll2",
@@ -2872,8 +2721,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.roll",
@@ -2884,8 +2732,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.roll2",
@@ -2896,8 +2743,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "o.addManeuverNode",
@@ -2910,8 +2756,7 @@
     "returnType": "object",
     "params": "float ut, float x, float y, float z",
     "formatter": "ManeuverNode",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.anVec",
@@ -2923,8 +2768,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.ApA",
@@ -2935,8 +2779,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.ApR",
@@ -2947,8 +2790,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.argumentOfPeriapsis",
@@ -2959,8 +2801,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.closestEncounterBody",
@@ -2971,8 +2812,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.closestTgtApprUT",
@@ -2983,8 +2823,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.eccentricAnomaly",
@@ -2995,8 +2834,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.eccentricity",
@@ -3007,8 +2845,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.eccVec",
@@ -3020,8 +2857,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.encounterBody",
@@ -3032,8 +2868,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.encounterExists",
@@ -3044,8 +2879,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "int",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.encounterTime",
@@ -3056,8 +2890,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.EndUT",
@@ -3068,8 +2901,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.epoch",
@@ -3080,8 +2912,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.gameLanguage",
@@ -3092,8 +2923,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "LangDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "LangDataLinkHandler"
   },
   {
     "key": "o.h",
@@ -3105,8 +2935,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.inclination",
@@ -3117,8 +2946,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.lan",
@@ -3129,8 +2957,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.maae",
@@ -3141,8 +2968,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes",
@@ -3154,8 +2980,7 @@
     "category": "maneuver",
     "returnType": "object",
     "formatter": "ManeuverNodeList",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.burnVector",
@@ -3168,8 +2993,7 @@
     "returnType": "Vector3d",
     "params": "int id",
     "formatter": "Vector3d",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.count",
@@ -3180,8 +3004,7 @@
     "alwaysEvaluable": false,
     "category": "maneuver",
     "returnType": "int",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.deltaV",
@@ -3194,8 +3017,7 @@
     "returnType": "Vector3d",
     "params": "int id",
     "formatter": "Vector3d",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.deltaVMagnitude",
@@ -3207,8 +3029,7 @@
     "category": "maneuver",
     "returnType": "double",
     "params": "int id",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.orbitPatches",
@@ -3221,8 +3042,7 @@
     "returnType": "object",
     "params": "int id",
     "formatter": "OrbitPatchList",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.relativePositionAtTrueAnomalyForManeuverNodesOrbitPatch",
@@ -3235,8 +3055,7 @@
     "returnType": "Vector3d",
     "params": "int id, int patchIndex, double trueAnomaly",
     "formatter": "Vector3d",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.relativePositionAtUTForManeuverNodesOrbitPatch",
@@ -3249,8 +3068,7 @@
     "returnType": "Vector3d",
     "params": "int id, int patchIndex, double UT",
     "formatter": "Vector3d",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.timeTo",
@@ -3262,8 +3080,7 @@
     "category": "maneuver",
     "returnType": "double",
     "params": "int id",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.trueAnomalyAtUTForManeuverNodesOrbitPatch",
@@ -3275,8 +3092,7 @@
     "category": "maneuver",
     "returnType": "double",
     "params": "int id, int patchIndex, double UT",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.UT",
@@ -3288,8 +3104,7 @@
     "category": "maneuver",
     "returnType": "double",
     "params": "int id",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.UTForTrueAnomalyForManeuverNodesOrbitPatch",
@@ -3301,8 +3116,7 @@
     "category": "maneuver",
     "returnType": "double",
     "params": "int id, int patchIndex, double trueAnomaly",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.mean.anomalisticPeriod",
@@ -3314,8 +3128,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.ApA",
@@ -3327,8 +3140,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.ApARange",
@@ -3340,8 +3152,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.argumentOfPeriapsis",
@@ -3353,8 +3164,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.eccentricity",
@@ -3366,8 +3176,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.eccentricityRange",
@@ -3379,8 +3188,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.inclination",
@@ -3392,8 +3200,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.inclinationRange",
@@ -3405,8 +3212,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.lan",
@@ -3418,8 +3224,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.nodalPeriod",
@@ -3431,8 +3236,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.nodalPrecession",
@@ -3444,8 +3248,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.PeA",
@@ -3457,8 +3260,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.PeARange",
@@ -3470,8 +3272,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.recurrence",
@@ -3483,8 +3284,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.siderealPeriod",
@@ -3496,8 +3296,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.sma",
@@ -3509,8 +3308,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.smaRange",
@@ -3522,8 +3320,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.meanAnomaly",
@@ -3534,8 +3331,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.nextApsisType",
@@ -3546,8 +3342,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitalEnergy",
@@ -3558,8 +3353,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitalSpeed",
@@ -3570,8 +3364,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitalSpeedAt",
@@ -3583,8 +3376,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "double obt",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitalSpeedAtDistance",
@@ -3596,8 +3388,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "double distance",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitNormal",
@@ -3609,8 +3400,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitPatches",
@@ -3622,8 +3412,7 @@
     "category": "orbit",
     "returnType": "object",
     "formatter": "OrbitPatchList",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitPercent",
@@ -3634,8 +3423,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.patchEndTransition",
@@ -3646,8 +3434,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.patchStartTransition",
@@ -3658,8 +3445,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.PeA",
@@ -3670,8 +3456,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.PeR",
@@ -3682,8 +3467,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.period",
@@ -3694,8 +3478,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.pos",
@@ -3707,8 +3490,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.radius",
@@ -3719,8 +3501,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.radiusAtTrueAnomaly",
@@ -3732,8 +3513,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "double trueAnomaly",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.referenceBody",
@@ -3744,8 +3524,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.relativePositionAtTrueAnomalyForOrbitPatch",
@@ -3758,8 +3537,7 @@
     "returnType": "Vector3d",
     "params": "int patchIndex, double trueAnomaly",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.relativePositionAtUTForOrbitPatch",
@@ -3772,8 +3550,7 @@
     "returnType": "Vector3d",
     "params": "int patchIndex, double UT",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.relativeVelocity",
@@ -3784,8 +3561,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.removeManeuverNode",
@@ -3797,8 +3573,7 @@
     "category": "maneuver",
     "returnType": "bool",
     "params": "int id",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.semiLatusRectum",
@@ -3809,8 +3584,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.semiMinorAxis",
@@ -3821,8 +3595,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.sma",
@@ -3833,8 +3606,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.StartUT",
@@ -3845,8 +3617,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeOfPeriapsisPassage",
@@ -3857,8 +3628,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeToAp",
@@ -3869,8 +3639,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeToNextApsis",
@@ -3881,8 +3650,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeToPe",
@@ -3893,8 +3661,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeToTransition1",
@@ -3905,8 +3672,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeToTransition2",
@@ -3917,8 +3683,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.trueAnomaly",
@@ -3929,8 +3694,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.trueAnomalyAtRadius",
@@ -3942,8 +3706,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "double radius",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.trueAnomalyAtUTForOrbitPatch",
@@ -3955,8 +3718,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "int patchIndex, double UT",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.updateManeuverNode",
@@ -3969,8 +3731,7 @@
     "returnType": "object",
     "params": "int id, float ut, float x, float y, float z",
     "formatter": "ManeuverNode",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.UTForTrueAnomalyForOrbitPatch",
@@ -3982,8 +3743,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "int patchIndex, double trueAnomaly",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.UTsoi",
@@ -3994,8 +3754,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.vel",
@@ -4007,8 +3766,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "p.paused",
@@ -4019,8 +3777,7 @@
     "alwaysEvaluable": true,
     "category": "system",
     "returnType": "int",
-    "declaringClass": "PausedDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/SystemHandlers.cs"
+    "declaringClass": "PausedDataLinkHandler"
   },
   {
     "key": "principia.active",
@@ -4032,8 +3789,7 @@
     "category": "principia",
     "returnType": "bool",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.analysis",
@@ -4045,8 +3801,7 @@
     "category": "principia",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.analysisProgress",
@@ -4058,8 +3813,7 @@
     "category": "principia",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.available",
@@ -4071,8 +3825,7 @@
     "category": "principia",
     "returnType": "bool",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.missionDuration",
@@ -4084,8 +3837,7 @@
     "category": "principia",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.plan.burn",
@@ -4098,8 +3850,7 @@
     "returnType": "object",
     "params": "int index",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.plan.burns",
@@ -4111,8 +3862,7 @@
     "category": "principia",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.plan.count",
@@ -4124,8 +3874,7 @@
     "category": "principia",
     "returnType": "int",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.plan.guidance",
@@ -4137,8 +3886,7 @@
     "category": "principia",
     "returnType": "bool",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.version",
@@ -4150,8 +3898,7 @@
     "category": "principia",
     "returnType": "string",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "r.resource",
@@ -4164,8 +3911,7 @@
     "returnType": "object",
     "params": "string resourceName",
     "formatter": "ResourceList",
-    "declaringClass": "ResourceDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "ResourceDataLinkHandler"
   },
   {
     "key": "r.resourceCurrent",
@@ -4178,8 +3924,7 @@
     "returnType": "object",
     "params": "string resourceName",
     "formatter": "ActiveResourceList",
-    "declaringClass": "ResourceDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "ResourceDataLinkHandler"
   },
   {
     "key": "r.resourceCurrentMax",
@@ -4192,8 +3937,7 @@
     "returnType": "object",
     "params": "string resourceName",
     "formatter": "MaxCurrentResourceList",
-    "declaringClass": "ResourceDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "ResourceDataLinkHandler"
   },
   {
     "key": "r.resourceMax",
@@ -4206,8 +3950,7 @@
     "returnType": "object",
     "params": "string resourceName",
     "formatter": "MaxResourceList",
-    "declaringClass": "ResourceDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "ResourceDataLinkHandler"
   },
   {
     "key": "r.resourceNameList",
@@ -4219,8 +3962,7 @@
     "category": "resource",
     "returnType": "string[]",
     "formatter": "StringArray",
-    "declaringClass": "ResourceDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "ResourceDataLinkHandler"
   },
   {
     "key": "rc.anyDeployed",
@@ -4232,8 +3974,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.arm",
@@ -4245,8 +3986,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.available",
@@ -4258,8 +3998,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.chutes",
@@ -4271,8 +4010,7 @@
     "category": "realchute",
     "returnType": "object",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.count",
@@ -4284,8 +4022,7 @@
     "category": "realchute",
     "returnType": "int",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.cut",
@@ -4297,8 +4034,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.deploy",
@@ -4310,8 +4046,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.disarm",
@@ -4323,8 +4058,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.safeState",
@@ -4336,8 +4070,29 @@
     "category": "realchute",
     "returnType": "string",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
+  },
+  {
+    "key": "recovery.hasRecent",
+    "description": "Whether a mission-summary snapshot has been captured this session (true after the first vessel is recovered).",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "recovery",
+    "returnType": "bool",
+    "declaringClass": "RecoveryDialogHandler"
+  },
+  {
+    "key": "recovery.lastSummary",
+    "description": "Most recent mission-summary snapshot. Includes vessel name, recovery location and factor, science/funds/reputation totals + earned + modifiers, and per-experiment, per-part, per-resource, per-crew breakdowns. Captures automatically when KSP completes recovery processing (no dialog dismissal needed). Persists across scene changes; cleared on KSP restart.",
+    "units": "UNITLESS",
+    "plotable": false,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "recovery",
+    "returnType": "object",
+    "declaringClass": "RecoveryDialogHandler"
   },
   {
     "key": "s.sensor",
@@ -4350,8 +4105,7 @@
     "returnType": "object",
     "params": "string sensorType",
     "formatter": "SensorModuleList",
-    "declaringClass": "SensorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "SensorDataLinkHandler"
   },
   {
     "key": "s.sensor.acc",
@@ -4363,8 +4117,7 @@
     "category": "sensor",
     "returnType": "object",
     "formatter": "SensorModuleList",
-    "declaringClass": "SensorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "SensorDataLinkHandler"
   },
   {
     "key": "s.sensor.grav",
@@ -4376,8 +4129,7 @@
     "category": "sensor",
     "returnType": "object",
     "formatter": "SensorModuleList",
-    "declaringClass": "SensorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "SensorDataLinkHandler"
   },
   {
     "key": "s.sensor.pres",
@@ -4389,8 +4141,7 @@
     "category": "sensor",
     "returnType": "object",
     "formatter": "SensorModuleList",
-    "declaringClass": "SensorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "SensorDataLinkHandler"
   },
   {
     "key": "s.sensor.temp",
@@ -4402,8 +4153,7 @@
     "category": "sensor",
     "returnType": "object",
     "formatter": "SensorModuleList",
-    "declaringClass": "SensorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "SensorDataLinkHandler"
   },
   {
     "key": "sci.count",
@@ -4414,8 +4164,7 @@
     "alwaysEvaluable": false,
     "category": "science",
     "returnType": "int",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "sci.dataAmount",
@@ -4426,8 +4175,7 @@
     "alwaysEvaluable": false,
     "category": "science",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "sci.experiments",
@@ -4438,8 +4186,7 @@
     "alwaysEvaluable": false,
     "category": "science",
     "returnType": "object",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "t.currentRate",
@@ -4450,8 +4197,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "double",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.currentRateIndex",
@@ -4462,8 +4208,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "double",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.deltaTime",
@@ -4474,8 +4219,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "double",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.isPaused",
@@ -4486,8 +4230,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "bool",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.maxPhysicsRate",
@@ -4498,8 +4241,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "double",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.universalTime",
@@ -4510,8 +4252,7 @@
     "alwaysEvaluable": true,
     "category": "timewarp",
     "returnType": "double",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.warpMode",
@@ -4522,8 +4263,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "string",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "tar.clearTarget",
@@ -4534,8 +4274,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "int",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.distance",
@@ -4546,8 +4285,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.groundDistance",
@@ -4558,8 +4296,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.name",
@@ -4570,8 +4307,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "string",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.ApA",
@@ -4582,8 +4318,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.argumentOfPeriapsis",
@@ -4594,8 +4329,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.eccentricity",
@@ -4606,8 +4340,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.inclination",
@@ -4618,8 +4351,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.lan",
@@ -4630,8 +4362,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.maae",
@@ -4642,8 +4373,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.orbitingBody",
@@ -4654,8 +4384,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "string",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.orbitPatches",
@@ -4667,8 +4396,7 @@
     "category": "target",
     "returnType": "double",
     "formatter": "OrbitPatchList",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.PeA",
@@ -4679,8 +4407,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.period",
@@ -4691,8 +4418,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.relativeInclination",
@@ -4703,8 +4429,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.relativePositionAtTrueAnomalyForOrbitPatch",
@@ -4717,8 +4442,7 @@
     "returnType": "double",
     "params": "int orbitPatchIndex, float trueAnomaly",
     "formatter": "Vector3d",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.relativePositionAtUTForOrbitPatch",
@@ -4731,8 +4455,7 @@
     "returnType": "double",
     "params": "int orbitPatchIndex, double universalTime",
     "formatter": "Vector3d",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.relativeVelocity",
@@ -4743,8 +4466,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.sma",
@@ -4755,8 +4477,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.timeOfPeriapsisPassage",
@@ -4767,8 +4488,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.timeToAp",
@@ -4779,8 +4499,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.timeToPe",
@@ -4791,8 +4510,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.timeToTransition1",
@@ -4803,8 +4521,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.timeToTransition2",
@@ -4815,8 +4532,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.trueAnomaly",
@@ -4827,8 +4543,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.trueAnomalyAtUTForOrbitPatch",
@@ -4840,8 +4555,7 @@
     "category": "target",
     "returnType": "double",
     "params": "int orbitPatchIndex, float universalTime",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.UTForTrueAnomalyForOrbitPatch",
@@ -4853,8 +4567,7 @@
     "category": "target",
     "returnType": "double",
     "params": "int orbitPatchIndex, float trueAnomaly",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.velocity",
@@ -4865,8 +4578,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.setTargetBody",
@@ -4878,8 +4590,7 @@
     "category": "target",
     "returnType": "int",
     "params": "int bodyId",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.setTargetVessel",
@@ -4891,8 +4602,7 @@
     "category": "target",
     "returnType": "int",
     "params": "int vesselIndex",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.type",
@@ -4903,8 +4613,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "string",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "therm.anyEnginesOverheating",
@@ -4915,8 +4624,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "bool",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.heatShieldFlux",
@@ -4927,8 +4635,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.heatShieldTemp",
@@ -4939,8 +4646,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.heatShieldTempCelsius",
@@ -4951,8 +4657,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestEngineMaxTemp",
@@ -4963,8 +4668,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestEngineTemp",
@@ -4975,8 +4679,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestEngineTempRatio",
@@ -4987,8 +4690,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestPartMaxTemp",
@@ -4999,8 +4701,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestPartName",
@@ -5011,8 +4712,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "string",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestPartTemp",
@@ -5023,8 +4723,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestPartTempKelvin",
@@ -5035,8 +4734,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestPartTempRatio",
@@ -5047,8 +4745,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "v.abortValue",
@@ -5059,8 +4756,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.acceleration",
@@ -5071,8 +4767,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.accelerationx",
@@ -5083,8 +4778,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.accelerationy",
@@ -5095,8 +4789,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.accelerationz",
@@ -5107,8 +4800,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.ag10Value",
@@ -5119,8 +4811,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag1Value",
@@ -5131,8 +4822,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag2Value",
@@ -5143,8 +4833,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag3Value",
@@ -5155,8 +4844,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag4Value",
@@ -5167,8 +4855,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag5Value",
@@ -5179,8 +4866,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag6Value",
@@ -5191,8 +4877,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag7Value",
@@ -5203,8 +4888,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag8Value",
@@ -5215,8 +4899,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag9Value",
@@ -5227,8 +4910,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.altitude",
@@ -5239,8 +4921,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angleToPrograde",
@@ -5251,8 +4932,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularMomentum",
@@ -5263,8 +4943,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularMomentumx",
@@ -5275,8 +4954,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularMomentumy",
@@ -5287,8 +4965,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularMomentumz",
@@ -5299,8 +4976,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularVelocity",
@@ -5311,8 +4987,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularVelocityx",
@@ -5323,8 +4998,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularVelocityy",
@@ -5335,8 +5009,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularVelocityz",
@@ -5347,8 +5020,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.atmosphericDensity",
@@ -5359,8 +5031,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.atmosphericPressure",
@@ -5371,8 +5042,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.atmosphericPressurePa",
@@ -5383,8 +5053,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.atmosphericTemperature",
@@ -5395,8 +5064,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.biome",
@@ -5407,8 +5075,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.biomeLocalized",
@@ -5419,8 +5086,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.body",
@@ -5431,8 +5097,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.brakeValue",
@@ -5443,8 +5108,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.CoM",
@@ -5456,8 +5120,7 @@
     "category": "vessel",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.crew",
@@ -5469,8 +5132,7 @@
     "category": "vessel",
     "returnType": "string[]",
     "formatter": "StringArray",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.crewCapacity",
@@ -5481,8 +5143,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "int",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.crewCount",
@@ -5493,8 +5154,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "int",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.currentStage",
@@ -5505,8 +5165,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "int",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.directSunlight",
@@ -5517,8 +5176,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.distanceToSun",
@@ -5529,8 +5187,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.dynamicPressure",
@@ -5541,8 +5198,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.dynamicPressurekPa",
@@ -5553,8 +5209,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.externalTemperature",
@@ -5565,8 +5220,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.gearValue",
@@ -5577,8 +5231,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.geeForce",
@@ -5589,8 +5242,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.geeForceImmediate",
@@ -5601,8 +5253,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.heightFromSurface",
@@ -5613,8 +5264,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.heightFromTerrain",
@@ -5625,8 +5275,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.indicatedAirSpeed",
@@ -5637,8 +5286,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.isActiveVessel",
@@ -5649,8 +5297,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.isCommandable",
@@ -5661,8 +5308,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.isControllable",
@@ -5673,8 +5319,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.isEVA",
@@ -5685,8 +5330,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.landed",
@@ -5697,8 +5341,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.landedAt",
@@ -5709,8 +5352,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.landedOrSplashed",
@@ -5721,8 +5363,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.lat",
@@ -5733,8 +5374,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.launchTime",
@@ -5745,8 +5385,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.lightValue",
@@ -5757,8 +5396,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.loaded",
@@ -5769,8 +5407,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.long",
@@ -5781,8 +5418,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.mach",
@@ -5793,8 +5429,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.mass",
@@ -5805,8 +5440,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.missionTime",
@@ -5817,8 +5451,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.missionTimeString",
@@ -5829,8 +5462,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.momentOfInertia",
@@ -5842,8 +5474,7 @@
     "category": "vessel",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.name",
@@ -5854,8 +5485,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.obtSpeed",
@@ -5866,8 +5496,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.orbitalVelocity",
@@ -5878,8 +5507,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.orbitalVelocityx",
@@ -5890,8 +5518,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.orbitalVelocityy",
@@ -5902,8 +5529,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.orbitalVelocityz",
@@ -5914,8 +5540,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.packed",
@@ -5926,8 +5551,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.perturbation",
@@ -5938,8 +5562,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.perturbationx",
@@ -5950,8 +5573,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.perturbationy",
@@ -5962,8 +5584,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.perturbationz",
@@ -5974,8 +5595,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.pqsAltitude",
@@ -5986,8 +5606,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.precisionControlValue",
@@ -5998,8 +5617,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.rcsValue",
@@ -6010,8 +5628,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.sasValue",
@@ -6022,8 +5639,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.setAttitude",
@@ -6035,8 +5651,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float pitch, float yaw, float roll",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setFbW",
@@ -6048,8 +5663,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "int state",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setPitch",
@@ -6061,8 +5675,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float pitch",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setPitchYawRollXYZ",
@@ -6074,8 +5687,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float pitch, float yaw, float roll, float x, float y, float z",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setRoll",
@@ -6087,8 +5699,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float roll",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setTranslation",
@@ -6100,8 +5711,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float x, float y, float z",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setYaw",
@@ -6113,8 +5723,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float yaw",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.situation",
@@ -6125,8 +5734,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.situationString",
@@ -6137,8 +5745,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.solarFlux",
@@ -6149,8 +5756,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.specificAcceleration",
@@ -6161,8 +5767,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.speed",
@@ -6173,8 +5778,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.speedOfSound",
@@ -6185,8 +5789,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.splashed",
@@ -6197,8 +5800,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.srfSpeed",
@@ -6209,8 +5811,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.staticPressure",
@@ -6221,8 +5822,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.staticPressurekPa",
@@ -6233,8 +5833,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.surfaceSpeed",
@@ -6245,8 +5844,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.surfaceVelocity",
@@ -6257,8 +5855,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.surfaceVelocityx",
@@ -6269,8 +5866,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.surfaceVelocityy",
@@ -6281,8 +5877,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.surfaceVelocityz",
@@ -6293,8 +5888,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.terrainHeight",
@@ -6305,8 +5899,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.terrainNormal",
@@ -6318,8 +5911,7 @@
     "category": "vessel",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.upAxis",
@@ -6331,8 +5923,7 @@
     "category": "vessel",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.verticalSpeed",
@@ -6343,8 +5934,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.vesselType",
@@ -6355,7 +5945,6 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   }
 ]

--- a/docs/api-schema.json
+++ b/docs/api-schema.json
@@ -861,7 +861,7 @@
   },
   {
     "key": "crash.lastCrash",
-    "description": "Most recent crash snapshot. Fields: vesselName, vesselId, body, situation, latitude, longitude, altitude, ut, what (what was hit), msg, eventKind (Crash/CrashSplashdown), partsLost (list of {partName, partTitle, partId, msg}), crewAboard (names), kerbalsKilled (names). Per-vessel events within 5 seconds coalesce into one snapshot; later vessels or later windows start fresh. Persists across scene changes; cleared on KSP restart.",
+    "description": "Most recent notable-vessel crash snapshot. Captures terrain (eventKind Crash), water (CrashSplashdown), and non-collision losses such as re-entry burn-up or structural break-up (Destroyed). Debris, flags, and unclassified vessels are excluded so they don't overwrite the last real crash. Fields: vesselName, vesselType (KSP VesselType e.g. Ship/Probe/SpaceObject), vesselId, body, situation, latitude, longitude, altitude, ut, what (what was hit; empty for Destroyed), msg, eventKind (Crash/CrashSplashdown/Destroyed), partsLost (list of {partName, partTitle, partId, msg}), crewAboard (names), kerbalsKilled (names), events (flight log), flightStats. Per-vessel collision events within 5 seconds coalesce into one snapshot. Persists across scene changes; cleared on KSP restart.",
     "units": "UNITLESS",
     "plotable": false,
     "isAction": false,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -80,6 +80,8 @@ tags:
     description: Career
   - name: comms
     description: Communications
+  - name: crash
+    description: crash
   - name: deltav
     description: Delta-V
   - name: docking
@@ -113,6 +115,8 @@ tags:
   - name: realchute
     description: RealChute (mod)
     x-requires-mod: realchute
+  - name: recovery
+    description: recovery
   - name: resource
     description: Resources
   - name: science
@@ -2026,6 +2030,47 @@ paths:
                   comm.signalStrength:
                     type: number
       x-plotable: true
+  "/api/crash.hasRecent":
+    get:
+      summary: Whether a crash snapshot has been captured this session.
+      operationId: crash.hasRecent
+      tags:
+        - crash
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  crash.hasRecent:
+                    type: boolean
+      x-plotable: true
+  "/api/crash.lastCrash":
+    get:
+      summary: "Most recent crash snapshot. Fields: vesselName, vesselId, body, situation, latitude, longitude, altitude, ut, what (what was hit), msg, eventKind (Crash/CrashSplashdown), partsLost (list of {partName, partTitle, partId, msg}), crewAboard (names), kerbalsKilled (names). Per-vessel events within 5 seconds coalesce into one snapshot; later vessels or later windows start fresh. Persists across scene changes; cleared on KSP restart."
+      operationId: crash.lastCrash
+      tags:
+        - crash
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  crash.lastCrash:
+                    type: object
   "/api/dock.ax":
     get:
       summary: Docking x Angle
@@ -4157,6 +4202,46 @@ paths:
                     type: boolean
       x-requires-mod: far
       x-plotable: true
+  "/api/flight.achievements":
+    get:
+      summary: "Running mission stats from KSP's FlightLogger — same data the Flight Results dialog renders in the Flight Achievements panel. Fields: missionTime, liftOff, highestAltitude, highestSpeed, highestSpeedOverLand, groundDistance, totalDistance, highestGee, partsLost (count), kerbalsKilled (count), missionEnd, flightEndMode. Returns null outside flight."
+      operationId: flight.achievements
+      tags:
+        - flight
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  flight.achievements:
+                    type: object
+  "/api/flight.events":
+    get:
+      summary: "Pre-formatted event timeline from KSP's FlightLogger — the same strings the in-game Flight Results dialog renders in the Flight Events panel. Empty list outside flight."
+      operationId: flight.events
+      tags:
+        - flight
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  flight.events:
+                    type: object
   "/api/kerbalism.available":
     get:
       summary: Kerbalism Is Installed
@@ -8574,6 +8659,47 @@ paths:
       x-requires-mod: realchute
       x-units: STRING
       x-plotable: true
+  "/api/recovery.hasRecent":
+    get:
+      summary: Whether a mission-summary snapshot has been captured this session (true after the first vessel is recovered).
+      operationId: recovery.hasRecent
+      tags:
+        - recovery
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  recovery.hasRecent:
+                    type: boolean
+      x-plotable: true
+  "/api/recovery.lastSummary":
+    get:
+      summary: Most recent mission-summary snapshot. Includes vessel name, recovery location and factor, science/funds/reputation totals + earned + modifiers, and per-experiment, per-part, per-resource, per-crew breakdowns. Captures automatically when KSP completes recovery processing (no dialog dismissal needed). Persists across scene changes; cleared on KSP restart.
+      operationId: recovery.lastSummary
+      tags:
+        - recovery
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  recovery.lastSummary:
+                    type: object
   "/api/s.sensor":
     get:
       summary: Sensor Information

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2053,7 +2053,7 @@ paths:
       x-plotable: true
   "/api/crash.lastCrash":
     get:
-      summary: "Most recent crash snapshot. Fields: vesselName, vesselId, body, situation, latitude, longitude, altitude, ut, what (what was hit), msg, eventKind (Crash/CrashSplashdown), partsLost (list of {partName, partTitle, partId, msg}), crewAboard (names), kerbalsKilled (names). Per-vessel events within 5 seconds coalesce into one snapshot; later vessels or later windows start fresh. Persists across scene changes; cleared on KSP restart."
+      summary: "Most recent notable-vessel crash snapshot. Captures terrain (eventKind Crash), water (CrashSplashdown), and non-collision losses such as re-entry burn-up or structural break-up (Destroyed). Debris, flags, and unclassified vessels are excluded so they don't overwrite the last real crash. Fields: vesselName, vesselType (KSP VesselType e.g. Ship/Probe/SpaceObject), vesselId, body, situation, latitude, longitude, altitude, ut, what (what was hit; empty for Destroyed), msg, eventKind (Crash/CrashSplashdown/Destroyed), partsLost (list of {partName, partTitle, partId, msg}), crewAboard (names), kerbalsKilled (names), events (flight log), flightStats. Per-vessel collision events within 5 seconds coalesce into one snapshot. Persists across scene changes; cleared on KSP restart."
       operationId: crash.lastCrash
       tags:
         - crash

--- a/tools/generate-openapi.ts
+++ b/tools/generate-openapi.ts
@@ -481,7 +481,9 @@ const outPath = resolve(outDir, "openapi.yaml");
 writeFileSync(outPath, yaml + "\n");
 console.log(`Written ${outPath}`);
 
-// Also write the merged JSON for easy consumption
+// Also write the merged JSON for easy consumption.
+// `sourceFile` is omitted here — kept on the in-memory entries for tooling use, off the committed artifact.
 const mergedJsonPath = resolve(outDir, "api-schema.json");
-writeFileSync(mergedJsonPath, JSON.stringify(all, null, 2) + "\n");
+const sanitized = all.map(({ sourceFile: _sourceFile, ...rest }) => rest);
+writeFileSync(mergedJsonPath, JSON.stringify(sanitized, null, 2) + "\n");
 console.log(`Written ${mergedJsonPath}`);


### PR DESCRIPTION
⚠️ I've used Claude to make this change and draft most of the description below. Built, tested locally in KSP, and happy with the result, so sharing here.

## Summary

Three new read-only handlers that snapshot mission-summary data via `GameEvents` subscriptions and expose it as standard telemetry keys:

| Key | Type | Description |
|-----|------|-------------|
| `recovery.lastSummary` | object | Last `MissionRecoveryDialog` content (vesselName, recoveryFactor, scienceEarned, fundsEarned, parts[], resources[], crew[], + FlightLogger stats) |
| `recovery.hasRecent` | bool | |
| `crash.lastCrash` | object | Vessel destruction event with crewAboard / kerbalsKilled / flightEndMode + FlightLogger stats |
| `crash.hasRecent` | bool | |
| `flight.events` | object | FlightLogger.eventLog snapshot (current flight, live) |
| `flight.achievements` | object | highest altitude / speed / G / partsLost / etc. |

All keys `AlwaysEvaluable = true` so they're queryable from Space Center / Tracking Station (post-flight summary panels, "last outcome" dashboards). Read-only — no `IsAction` handlers.

## Subscription lifecycle (a quirk of KSP's EventData)

`EventData<T>.EvtDelegate` reads `evt.Target.GetType()` unconditionally in its ctor. Subscribing from a static method (or from `KSPAPI..ctor` before the target object exists) NREs at module load. So each handler keeps a paired `*Subscriber : MonoBehaviour` ([`KSPAddon(Startup.MainMenu, true)`]) that subscribes on Awake and trampolines into the handler's static state.

The `CrashDataHandler` subscriber also runs `Update()` at 0.5Hz to track `ActiveVessel.GetVesselCrew()` — `onCrewKilled` fires *before* `onCrash`, so the handler buffers pending kills in a static list and drains them at crash time to reliably attach kerbal names to the crash record.

## Known limitation

`PRELAUNCH` recovery (the cheap launchpad refund path) doesn't fire `onVesselRecoveryProcessingComplete`, so it produces no snapshot. Flight-scene recoveries and the post-landing summary dialog both work.

## Validation

Tested locally on KSP 1.12.x with a custom HTTP/WS dashboard, in a career save:

- **Recovery flow:** launched a probe, flew, recovered. `recovery.hasRecent` flipped to `true`, `recovery.lastSummary` populated with the vessel name, location, scienceEarned, fundsEarned, recovery factor, plus the parts/resources/crew breakdown matching what the in-game dialog showed.
- **Crash flow:** launched Valentina, crashed. `crash.hasRecent` flipped to `true`, `crash.lastCrash` populated with `crewAboard: ["Valentina Kerman"]`, `kerbalsKilled: ["Valentina Kerman"]`, `flightEndMode: "CATASTROPHIC_FAILURE"`, and the FlightLogger stats block (highest altitude / speed / G / partsLost / etc.). The crash-on-water and crash-on-land variants both report correctly via `flightEndMode`.
- **Live FlightLogger:** `flight.events` and `flight.achievements` ticked during ascent — confirmed `flight.achievements.highestAltitude` and `flight.achievements.highestSpeed` updating in real time.
- **Cross-scene query:** after recovery, queried `recovery.lastSummary` from the Space Center scene and got the same snapshot back.
- **Startup:** no NREs on KSP load — the deferred MainMenu subscribe pattern works.
