### PR TITLE
feat: career-mode handler surface (tech / kc / sci / contracts / launch / actiongroups)

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,7 @@ SAS modes: `StabilityAssist`, `Prograde`, `Retrograde`, `Normal`, `Antinormal`, 
 | `f.abort` | **Action:** trigger abort |
 | `f.ag1` … `f.ag10` | **Action:** custom action groups |
 | `f.stage` | **Action:** activate next stage |
+| `f.ag.bindings` | Flat per-action listing of which parts are bound to each action group on the active vessel. One row per (action, group) pair; unbound actions are omitted. |
 
 </details>
 
@@ -752,11 +753,11 @@ Example: `r.resource[ElectricCharge]`, `r.resource[LiquidFuel]`, `r.resource[Oxi
 
 ### `tech.*` — Tech tree
 
-All `AlwaysEvaluable` — queryable from any scene.
+Callable from any game scene.
 
 | Key | Description |
 |-----|-------------|
-| `tech.nodes` | Full tech tree — every node with `id`, `title`, `description`, `scienceCost` (nominal) + `scienceCostEffective` (after `CurrencyModifierQuery` against `RnDTechResearch`), `state` (`Available` / `Researchable` / `Unavailable`), `parents` (prerequisite node IDs), and `parts` (list of `{name, title, manufacturer, category, entryCost, entryCostEffective (RnDPartPurchase modifier), purchased}` for every part assigned to the node) |
+| `tech.nodes` | Full tech tree — every node with its title, description, science cost, prerequisites, state (Available / Researchable / Unavailable), and the parts it unlocks. Costs include both nominal and strategy-modified effective values. See the OpenAPI schema for field detail. |
 | `tech.unlockedIds` | All currently unlocked node IDs |
 | `tech.unlockedPartCount` | Count of unlocked parts |
 | `tech.affordable` | Unpurchased nodes affordable right now (with cost / scienceRequired) |
@@ -767,12 +768,12 @@ All `AlwaysEvaluable` — queryable from any scene.
 | Key | Description |
 |-----|-------------|
 | `kc.scene` | Current scene name (`SPACECENTER`, `FLIGHT`, `EDITOR`, `TRACKSTATION`, …) |
-| `kc.facilityLevels` | All ScenarioUpgradeableFacilities with `level`, `max`, `upgradeFunds` (nominal) + `upgradeFundsEffective` (after KSP's `CurrencyModifierQuery` against `StructureConstruction` — strategy effects baked in), and the multi-line `currentLevelText` / `nextLevelText` descriptions KSP shows in the upgrade dialog |
+| `kc.facilityLevels` | All Space Center facilities — current level, max level, upgrade cost (nominal and strategy-modified), and the multi-line descriptions KSP shows in its upgrade dialog |
 | `kc.launchSite` | Active launch site (`LaunchPad` / `Runway`) |
 | `kc.padOccupied` / `kc.padVesselTitle` | Pad state |
 | `kc.partsAvailable` | All purchasable parts with their availability + cost |
-| `kc.savedShips` | Saved craft listing per facility, each with `name`, `partCount`, `totalMass`, `facility`, `requiresFunds` (nominal) + `requiresFundsEffective` (after `CurrencyModifierQuery` against `VesselRollout`), `missingParts` |
-| `kc.crewRoster` | Full kerbal roster with courage / stupidity / badass / veteran / gender / type / experience / careerFlights / careerEntries / currentVesselId / currentVesselName |
+| `kc.savedShips` | Saved craft per facility — name, part count, mass, rollout cost (nominal and strategy-modified), and any missing-part references |
+| `kc.crewRoster` | Full kerbal roster — name, stats, experience, and current assignment |
 | `kc.upgradeFacility[facilityName]` | **Action:** start a facility upgrade; deducts funds |
 
 ### `sci.*` — Science
@@ -814,10 +815,6 @@ All `AlwaysEvaluable` action keys for launch / recovery / revert / scene transit
 | `ksp.revertToEditor[vab\|sph]` | **Action:** revert to the editor scene (Flight only) |
 | `ksp.toSpaceCenter` / `ksp.toTrackingStation` | **Action:** switch scenes |
 | `ksp.canRevert` / `ksp.canRevertToLaunch` / `ksp.canRevertToEditor` | Whether the corresponding revert path is available (mirrors `FlightDriver.CanRevert*`) |
-
-### Action group bindings
-
-`f.ag.bindings` — flat per-action list of action-group bindings on the active vessel: `{ actionGroup, partId, partName, partTitle, moduleName, actionName, actionGuiName }`. One row per (action, group) pair (an action bound to two groups emits two rows; actions with no group are omitted).
 
 ### Camera API
 
@@ -1090,25 +1087,34 @@ Each burn object contains `{ tangent, normal, binormal, initial_time, duration }
 | `therm.heatShieldTempCelsius` | Heat shield temperature | C |
 | `therm.heatShieldFlux` | Heat shield thermal flux | kW |
 
-### `sci.*` / `career.*` / `comm.*` — Science, career & comms *(WIP — in testing)*
+### `career.*` — Career mode
 
 | Key | Description |
 |-----|-------------|
-| `sci.count` | Number of science experiments aboard |
-| `sci.dataAmount` | Total science data aboard |
-| `sci.experiments` | Experiments with data (object) |
 | `career.funds` | Available funds |
 | `career.reputation` | Current reputation |
 | `career.science` | Available science points |
 | `career.mode` | Game mode (CAREER / SCIENCE / SANDBOX) |
+
+### `comm.*` — CommNet
+
+| Key | Description |
+|-----|-------------|
 | `comm.connected` | CommNet is connected |
 | `comm.signalStrength` | CommNet signal strength (0–1) |
 | `comm.controlState` | CommNet control state (0=none, 1=partial, 2=full) |
 | `comm.controlStateName` | CommNet control state name |
 | `comm.signalDelay` | CommNet signal delay (s) |
-| `strategies.all` | All career strategies — id, title, description, departmentName, isActive, factor, dateActivated, initialCost{Funds,Science,Reputation} (nominal), effectiveCostReputation (post reputation-curve), requiredReputation, leastDuration/longestDuration, noDuration, hasFactorSlider/factorSliderDefault/factorSliderSteps, canActivate/activateBlockedReason, canDeactivate/deactivateBlockedReason, effect text. AlwaysEvaluable. |
-| `strategies.activate[id,factor]` | **Action:** activate a strategy by id, setting the commitment factor (`[0, 1]`) before activation. Returns `0` on success, error string otherwise. Works in any scene — the gate logic replicates KSP's `CanBeActivated` against `StrategySystem` / `GameVariables` / `Funding` / `Reputation` / R&D state without needing the (dialog-only-live) `Administration` singleton. |
-| `strategies.deactivate[id]` | **Action:** deactivate an active strategy by id. Returns `0` on success. Same in-any-scene reach as `strategies.activate`. |
+
+### `strategies.*` — Administration Building strategies
+
+Callable from any game scene — the activate / deactivate path replicates KSP's eligibility checks against live state, so the Admin Building dialog does not need to be open.
+
+| Key | Description |
+|-----|-------------|
+| `strategies.all` | All career strategies (active and inactive) with title, description, department, current activation state, costs (nominal and strategy-modified), reputation requirements, factor-slider info, and pre-computed `canActivate` / `canDeactivate` flags with human-readable blocked reasons |
+| `strategies.activate[id, factor]` | **Action:** activate a strategy at the given commitment factor (0–1). Returns `0` on success, error string otherwise. |
+| `strategies.deactivate[id]` | **Action:** deactivate an active strategy. Returns `0` on success, error string otherwise. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -756,7 +756,7 @@ All `AlwaysEvaluable` — queryable from any scene.
 
 | Key | Description |
 |-----|-------------|
-| `tech.nodes` | Full tech tree — every node with `id`, `title`, `description`, `scienceCost`, `state` (`Available` / `Researchable` / `Unavailable`), `parents` (prerequisite node IDs), and `parts` (list of `{name, title, manufacturer, category, entryCost, purchased}` for every part assigned to the node) |
+| `tech.nodes` | Full tech tree — every node with `id`, `title`, `description`, `scienceCost` (nominal) + `scienceCostEffective` (after `CurrencyModifierQuery` against `RnDTechResearch`), `state` (`Available` / `Researchable` / `Unavailable`), `parents` (prerequisite node IDs), and `parts` (list of `{name, title, manufacturer, category, entryCost, entryCostEffective (RnDPartPurchase modifier), purchased}` for every part assigned to the node) |
 | `tech.unlockedIds` | All currently unlocked node IDs |
 | `tech.unlockedPartCount` | Count of unlocked parts |
 | `tech.affordable` | Unpurchased nodes affordable right now (with cost / scienceRequired) |
@@ -767,11 +767,11 @@ All `AlwaysEvaluable` — queryable from any scene.
 | Key | Description |
 |-----|-------------|
 | `kc.scene` | Current scene name (`SPACECENTER`, `FLIGHT`, `EDITOR`, `TRACKSTATION`, …) |
-| `kc.facilityLevels` | All ScenarioUpgradeableFacilities with `level`, `max`, `upgradeFunds`, and the multi-line `currentLevelText` / `nextLevelText` descriptions KSP shows in the upgrade dialog |
+| `kc.facilityLevels` | All ScenarioUpgradeableFacilities with `level`, `max`, `upgradeFunds` (nominal) + `upgradeFundsEffective` (after KSP's `CurrencyModifierQuery` against `StructureConstruction` — strategy effects baked in), and the multi-line `currentLevelText` / `nextLevelText` descriptions KSP shows in the upgrade dialog |
 | `kc.launchSite` | Active launch site (`LaunchPad` / `Runway`) |
 | `kc.padOccupied` / `kc.padVesselTitle` | Pad state |
 | `kc.partsAvailable` | All purchasable parts with their availability + cost |
-| `kc.savedShips` | Saved craft listing per facility |
+| `kc.savedShips` | Saved craft listing per facility, each with `name`, `partCount`, `totalMass`, `facility`, `requiresFunds` (nominal) + `requiresFundsEffective` (after `CurrencyModifierQuery` against `VesselRollout`), `missingParts` |
 | `kc.crewRoster` | Full kerbal roster with courage / stupidity / badass / veteran / gender / type / experience / careerFlights / careerEntries / currentVesselId / currentVesselName |
 | `kc.upgradeFacility[facilityName]` | **Action:** start a facility upgrade; deducts funds |
 
@@ -1106,6 +1106,9 @@ Each burn object contains `{ tangent, normal, binormal, initial_time, duration }
 | `comm.controlState` | CommNet control state (0=none, 1=partial, 2=full) |
 | `comm.controlStateName` | CommNet control state name |
 | `comm.signalDelay` | CommNet signal delay (s) |
+| `strategies.all` | All career strategies — id, title, description, departmentName, isActive, factor, dateActivated, initialCost{Funds,Science,Reputation} (nominal), effectiveCostReputation (post reputation-curve), requiredReputation, leastDuration/longestDuration, noDuration, hasFactorSlider/factorSliderDefault/factorSliderSteps, canActivate/activateBlockedReason, canDeactivate/deactivateBlockedReason, effect text. AlwaysEvaluable. |
+| `strategies.activate[id,factor]` | **Action:** activate a strategy by id, setting the commitment factor (`[0, 1]`) before activation. Returns `0` on success, error string otherwise. Works in any scene — the gate logic replicates KSP's `CanBeActivated` against `StrategySystem` / `GameVariables` / `Funding` / `Reputation` / R&D state without needing the (dialog-only-live) `Administration` singleton. |
+| `strategies.deactivate[id]` | **Action:** deactivate an active strategy by id. Returns `0` on success. Same in-any-scene reach as `strategies.activate`. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -756,6 +756,7 @@ All `AlwaysEvaluable` — queryable from any scene.
 
 | Key | Description |
 |-----|-------------|
+| `tech.nodes` | Full tech tree — every node with `id`, `title`, `description`, `scienceCost`, `state` (`Available` / `Researchable` / `Unavailable`), `parents` (prerequisite node IDs), and `parts` (list of `{name, title, manufacturer, category, entryCost, purchased}` for every part assigned to the node) |
 | `tech.unlockedIds` | All currently unlocked node IDs |
 | `tech.unlockedPartCount` | Count of unlocked parts |
 | `tech.affordable` | Unpurchased nodes affordable right now (with cost / scienceRequired) |
@@ -766,7 +767,7 @@ All `AlwaysEvaluable` — queryable from any scene.
 | Key | Description |
 |-----|-------------|
 | `kc.scene` | Current scene name (`SPACECENTER`, `FLIGHT`, `EDITOR`, `TRACKSTATION`, …) |
-| `kc.facilityLevels` | All ScenarioUpgradeableFacilities with current + max upgrade levels |
+| `kc.facilityLevels` | All ScenarioUpgradeableFacilities with `level`, `max`, `upgradeFunds`, and the multi-line `currentLevelText` / `nextLevelText` descriptions KSP shows in the upgrade dialog |
 | `kc.launchSite` | Active launch site (`LaunchPad` / `Runway`) |
 | `kc.padOccupied` / `kc.padVesselTitle` | Pad state |
 | `kc.partsAvailable` | All purchasable parts with their availability + cost |

--- a/README.md
+++ b/README.md
@@ -750,6 +750,74 @@ Example: `r.resource[ElectricCharge]`, `r.resource[LiquidFuel]`, `r.resource[Oxi
 | `a.physicsMode` | `"patched_conics"` or `"n_body"` (Principia) |
 | `a.schema` | Full API schema as JSON |
 
+### `tech.*` — Tech tree
+
+All `AlwaysEvaluable` — queryable from any scene.
+
+| Key | Description |
+|-----|-------------|
+| `tech.unlockedIds` | All currently unlocked node IDs |
+| `tech.unlockedPartCount` | Count of unlocked parts |
+| `tech.affordable` | Unpurchased nodes affordable right now (with cost / scienceRequired) |
+| `tech.unlock[nodeId]` | **Action:** purchase a node by ID; returns `0` on success or an error string |
+
+### `kc.*` — KSC / Space Center
+
+| Key | Description |
+|-----|-------------|
+| `kc.scene` | Current scene name (`SPACECENTER`, `FLIGHT`, `EDITOR`, `TRACKSTATION`, …) |
+| `kc.facilityLevels` | All ScenarioUpgradeableFacilities with current + max upgrade levels |
+| `kc.launchSite` | Active launch site (`LaunchPad` / `Runway`) |
+| `kc.padOccupied` / `kc.padVesselTitle` | Pad state |
+| `kc.partsAvailable` | All purchasable parts with their availability + cost |
+| `kc.savedShips` | Saved craft listing per facility |
+| `kc.crewRoster` | Full kerbal roster with courage / stupidity / badass / veteran / gender / type / experience / careerFlights / careerEntries / currentVesselId / currentVesselName |
+| `kc.upgradeFacility[facilityName]` | **Action:** start a facility upgrade; deducts funds |
+
+### `sci.*` — Science
+
+| Key | Description |
+|-----|-------------|
+| `sci.count` / `sci.dataAmount` | Science container summary |
+| `sci.canRecoverTotal` / `sci.canTransmitTotal` | Aggregate recoverable / transmittable |
+| `sci.instruments` | All ModuleScienceExperiment instances on the active vessel |
+| `sci.experiments` | Stored experiment data |
+| `sci.experimentBreakdown` | Per-experiment breakdown (subject / amount / dataScale) |
+| `sci.deploy[partFlightId, experimentId]` | **Action:** deploy an experiment |
+| `sci.dump[partFlightId]` | **Action:** dump stored science from a container |
+| `sci.reset[partFlightId]` | **Action:** reset an experiment |
+| `sci.transmit[partFlightId]` | **Action:** transmit stored science |
+
+### `contracts.*` — Contracts
+
+Contract IDs are emitted as **strings** (KSP-generated long values frequently exceed JS `Number.MAX_SAFE_INTEGER`). Action handlers accept both string and number forms.
+
+| Key | Description |
+|-----|-------------|
+| `contracts.active` | Active contracts; rows include id, title, agent, parameters (with `parameterType` + typed fields per parameter) |
+| `contracts.offered` | Offered (un-accepted) contracts |
+| `contracts.completedRecent` | Recently-completed contracts |
+| `contracts.accept[id]` | **Action:** accept an offered contract |
+| `contracts.decline[id]` | **Action:** decline an offered contract |
+| `contracts.cancel[id]` | **Action:** cancel an active contract |
+
+### `ksp.*` — Scene & vessel verbs
+
+All `AlwaysEvaluable` action keys for launch / recovery / revert / scene transitions. Each refuses internally when the underlying state isn't ready.
+
+| Key | Description |
+|-----|-------------|
+| `ksp.launch[shipName, facility, site, crewSemicolons]` | **Action:** load a saved craft to the chosen pad. Refuses outside SC/Editor or if an active vessel exists. Crew names delimited by `;` (since `,` is already an arg separator). |
+| `ksp.recover` | **Action:** recover active vessel (PRELAUNCH / LANDED / SPLASHED only) |
+| `ksp.revertToLaunch` | **Action:** revert to the post-init launch snapshot (Flight only) |
+| `ksp.revertToEditor[vab\|sph]` | **Action:** revert to the editor scene (Flight only) |
+| `ksp.toSpaceCenter` / `ksp.toTrackingStation` | **Action:** switch scenes |
+| `ksp.canRevert` / `ksp.canRevertToLaunch` / `ksp.canRevertToEditor` | Whether the corresponding revert path is available (mirrors `FlightDriver.CanRevert*`) |
+
+### Action group bindings
+
+`f.ag.bindings` — flat per-action list of action-group bindings on the active vessel: `{ actionGroup, partId, partName, partTitle, moduleName, actionName, actionGuiName }`. One row per (action, group) pair (an action bound to two groups emits two rows; actions with no group are omitted).
+
 ### Camera API
 
 ```

--- a/README.md
+++ b/README.md
@@ -767,7 +767,7 @@ Callable from any game scene.
 
 | Key | Description |
 |-----|-------------|
-| `kc.scene` | Current scene name (`SPACECENTER`, `FLIGHT`, `EDITOR`, `TRACKSTATION`, …) |
+| `kc.scene` | Current scene name (`SPACECENTER`, `FLIGHT`, `EDITOR`, or `TRACKSTATION`) |
 | `kc.facilityLevels` | All Space Center facilities — current level, max level, upgrade cost (nominal and strategy-modified), and the multi-line descriptions KSP shows in its upgrade dialog |
 | `kc.launchSite` | Active launch site (`LaunchPad` / `Runway`) |
 | `kc.padOccupied` / `kc.padVesselTitle` | Pad state |

--- a/Telemachus/src/ActionGroupBindingsDataLinkHandler.cs
+++ b/Telemachus/src/ActionGroupBindingsDataLinkHandler.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+
+namespace Telemachus
+{
+    /// <summary>Reverse-index of action-group → bound parts/actions on the active vessel. Poll on demand, not at telemetry tick rate.</summary>
+    public class ActionGroupBindingsDataLinkHandler : DataLinkHandler
+    {
+        public ActionGroupBindingsDataLinkHandler(FormatterProvider formatters)
+            : base(formatters) { }
+
+        // Explicit list skips REPLACEWITHDEFAULT/None from Enum.GetValues and pins iteration order.
+        private static readonly KSPActionGroup[] AllGroups = new[]
+        {
+            KSPActionGroup.Stage,
+            KSPActionGroup.Gear,
+            KSPActionGroup.Light,
+            KSPActionGroup.RCS,
+            KSPActionGroup.SAS,
+            KSPActionGroup.Brakes,
+            KSPActionGroup.Abort,
+            KSPActionGroup.Custom01,
+            KSPActionGroup.Custom02,
+            KSPActionGroup.Custom03,
+            KSPActionGroup.Custom04,
+            KSPActionGroup.Custom05,
+            KSPActionGroup.Custom06,
+            KSPActionGroup.Custom07,
+            KSPActionGroup.Custom08,
+            KSPActionGroup.Custom09,
+            KSPActionGroup.Custom10,
+        };
+
+        [TelemetryAPI("f.ag.bindings",
+            "Per-action flat list of action-group bindings on the active " +
+            "vessel: { actionGroup, partId, partName, partTitle, " +
+            "moduleName, actionName, actionGuiName }. One row per " +
+            "(action, group) pair — an action bound to two groups emits " +
+            "two rows. Actions with no group (None) are omitted.",
+            Plotable = false,
+            Category = "control",
+            ReturnType = "object")]
+        object Bindings(DataSources ds)
+        {
+            var result = new List<Dictionary<string, object>>();
+            var vessel = ds.vessel;
+            if (vessel?.parts == null) return result;
+
+            foreach (var part in vessel.parts)
+            {
+                if (part == null) continue;
+                var partId = part.flightID;
+                var partName = part.partInfo?.name ?? part.name ?? string.Empty;
+                var partTitle = part.partInfo?.title ?? string.Empty;
+
+                if (part.Actions != null)
+                {
+                    foreach (var action in part.Actions)
+                    {
+                        EmitIfBound(result, action, string.Empty, partId, partName, partTitle);
+                    }
+                }
+
+                if (part.Modules != null)
+                {
+                    foreach (PartModule module in part.Modules)
+                    {
+                        if (module?.Actions == null) continue;
+                        var moduleName = module.moduleName ?? string.Empty;
+                        foreach (var action in module.Actions)
+                        {
+                            EmitIfBound(result, action, moduleName, partId, partName, partTitle);
+                        }
+                    }
+                }
+            }
+            return result;
+        }
+
+        private static void EmitIfBound(
+            List<Dictionary<string, object>> result,
+            BaseAction action,
+            string moduleName,
+            uint partId,
+            string partName,
+            string partTitle)
+        {
+            if (action == null) return;
+            var bound = action.actionGroup;
+            if (bound == KSPActionGroup.None) return;
+
+            // actionGroup is a flags bitmask — mods can set multiple bits; emit one row per matched flag.
+            foreach (var ag in AllGroups)
+            {
+                if ((bound & ag) == 0) continue;
+                result.Add(new Dictionary<string, object>
+                {
+                    ["actionGroup"] = ag.ToString(),
+                    ["partId"] = partId,
+                    ["partName"] = partName,
+                    ["partTitle"] = partTitle,
+                    ["moduleName"] = moduleName,
+                    ["actionName"] = action.name ?? string.Empty,
+                    ["actionGuiName"] = action.guiName ?? string.Empty,
+                });
+            }
+        }
+    }
+}

--- a/Telemachus/src/ContractsDataLinkHandler.cs
+++ b/Telemachus/src/ContractsDataLinkHandler.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Collections.Generic;
+using Contracts;
+
+namespace Telemachus
+{
+    /// <summary>Contract lists + accept/decline/cancel verbs. Wire shape mirrors KSP's Contract directly; deadline arithmetic happens client-side via t.universalTime.</summary>
+    public class ContractsDataLinkHandler : DataLinkHandler
+    {
+        private const int RECENT_LIMIT = 20;
+
+        public ContractsDataLinkHandler(FormatterProvider formatters)
+            : base(formatters) { }
+
+        private static double R4(double v)
+        {
+            if (double.IsNaN(v) || double.IsInfinity(v)) return v;
+            return Math.Round(v, 4);
+        }
+
+        [TelemetryAPI("contracts.active",
+            "All Active contracts with parameters + reward shape",
+            AlwaysEvaluable = true,
+            Plotable = false,
+            Category = "career",
+            ReturnType = "object")]
+        object Active(DataSources ds) => ContractsByState(Contract.State.Active);
+
+        [TelemetryAPI("contracts.offered",
+            "Contracts in Mission Control awaiting accept",
+            AlwaysEvaluable = true,
+            Plotable = false,
+            Category = "career",
+            ReturnType = "object")]
+        object Offered(DataSources ds) => ContractsByState(Contract.State.Offered);
+
+        [TelemetryAPI("contracts.completedRecent",
+            "Last N completed-or-failed contracts, newest-first",
+            AlwaysEvaluable = true,
+            Plotable = false,
+            Category = "career",
+            ReturnType = "object")]
+        object CompletedRecent(DataSources ds)
+        {
+            var result = new List<Dictionary<string, object>>();
+            var system = ContractSystem.Instance;
+            if (system == null) return result;
+
+            var finished = system.ContractsFinished;
+            if (finished == null && system.Contracts != null)
+            {
+                finished = new List<Contract>();
+                foreach (var c in system.Contracts)
+                {
+                    if (c == null) continue;
+                    if (c.ContractState == Contract.State.Completed ||
+                        c.ContractState == Contract.State.Failed)
+                        finished.Add(c);
+                }
+            }
+            if (finished == null) return result;
+
+            var ordered = new List<Contract>(finished);
+            ordered.Sort((a, b) =>
+            {
+                var ad = a != null ? a.DateFinished : 0;
+                var bd = b != null ? b.DateFinished : 0;
+                return bd.CompareTo(ad);
+            });
+
+            for (var i = 0; i < ordered.Count && result.Count < RECENT_LIMIT; i++)
+            {
+                if (ordered[i] == null) continue;
+                result.Add(SerialiseContract(ordered[i]));
+            }
+            return result;
+        }
+
+        private static List<Dictionary<string, object>> ContractsByState(Contract.State state)
+        {
+            var result = new List<Dictionary<string, object>>();
+            var system = ContractSystem.Instance;
+            if (system == null || system.Contracts == null) return result;
+
+            foreach (var c in system.Contracts)
+            {
+                if (c == null || c.ContractState != state) continue;
+                result.Add(SerialiseContract(c));
+            }
+            return result;
+        }
+
+        private static Dictionary<string, object> SerialiseContract(Contract c)
+        {
+            return new Dictionary<string, object>
+            {
+                // String — contract IDs are 64-bit and exceed JSON-number 2^53 precision.
+                ["id"] = c.ContractID.ToString(),
+                ["title"] = c.Title ?? string.Empty,
+                ["agency"] = c.Agent != null ? c.Agent.Name : string.Empty,
+                ["state"] = c.ContractState.ToString(),
+                ["fundsAdvance"] = R4(c.FundsAdvance),
+                ["fundsCompletion"] = R4(c.FundsCompletion),
+                ["fundsFailure"] = R4(c.FundsFailure),
+                ["scienceCompletion"] = R4(c.ScienceCompletion),
+                ["repCompletion"] = R4(c.ReputationCompletion),
+                ["deadlineUt"] = R4(c.DateExpire),
+                ["parameters"] = SerialiseParameters(c),
+            };
+        }
+
+        private static List<Dictionary<string, object>> SerialiseParameters(Contract c)
+        {
+            var result = new List<Dictionary<string, object>>();
+            var parameters = c.AllParameters;
+            if (parameters == null) return result;
+            foreach (var p in parameters)
+            {
+                if (p == null) continue;
+                var entry = new Dictionary<string, object>
+                {
+                    ["title"] = p.Title ?? string.Empty,
+                    ["state"] = p.State.ToString(),
+                    ["optional"] = p.Optional,
+                };
+                EmitTypeSpecificFields(p, entry);
+                result.Add(entry);
+            }
+            return result;
+        }
+
+        // Merges per-subclass condition fields (altitude band, body, part name, …) so clients can render progress beyond the binary State enum.
+        private static void EmitTypeSpecificFields(ContractParameter p, Dictionary<string, object> entry)
+        {
+            switch (p)
+            {
+                case Contracts.Parameters.ReachAltitudeEnvelope alt:
+                    entry["parameterType"] = "ReachAltitudeEnvelope";
+                    entry["minAltitude"] = R4(alt.minAltitude);
+                    entry["maxAltitude"] = R4(alt.maxAltitude);
+                    break;
+
+                case Contracts.Parameters.ReachSituation sit:
+                    entry["parameterType"] = "ReachSituation";
+                    entry["situation"] = sit.Situation.ToString();
+                    break;
+
+                case Contracts.Parameters.ReachDestination dest:
+                    entry["parameterType"] = "ReachDestination";
+                    entry["body"] = dest.Destination?.bodyName ?? string.Empty;
+                    break;
+
+                case Contracts.Parameters.PartTest pt:
+                    entry["parameterType"] = "PartTest";
+                    entry["partName"] = pt.partName ?? string.Empty;
+                    entry["body"] = pt.body ?? string.Empty;
+                    entry["situation"] = pt.situation ?? string.Empty;
+                    entry["hauled"] = pt.hauled;
+                    break;
+            }
+        }
+
+        private static Contract FindContract(IList<string> args)
+        {
+            if (args == null || args.Count == 0) return null;
+            if (!long.TryParse(args[0], out var id)) return null;
+            var system = ContractSystem.Instance;
+            if (system == null || system.Contracts == null) return null;
+            foreach (var c in system.Contracts)
+            {
+                if (c != null && c.ContractID == id) return c;
+            }
+            return null;
+        }
+
+        [TelemetryAPI("contracts.accept",
+            "Accept an Offered contract (moves to Active)",
+            AlwaysEvaluable = true,
+            IsAction = true,
+            Category = "career",
+            ReturnType = "object",
+            Params = "long contractId")]
+        object Accept(DataSources ds)
+        {
+            if (ds.args == null || ds.args.Count == 0) return "missing contract id";
+            if (!long.TryParse(ds.args[0], out _)) return "invalid contract id";
+            var found = FindContract(ds.args);
+            if (found == null) return "contract not found";
+            if (found.ContractState == Contract.State.Active) return 0; // idempotent
+            if (found.ContractState != Contract.State.Offered)
+                return "contract not in Offered state";
+            found.Accept();
+            return 0;
+        }
+
+        [TelemetryAPI("contracts.decline",
+            "Decline an Offered contract — different verb from cancel; only valid for Offered",
+            AlwaysEvaluable = true,
+            IsAction = true,
+            Category = "career",
+            ReturnType = "object",
+            Params = "long contractId")]
+        object Decline(DataSources ds)
+        {
+            if (ds.args == null || ds.args.Count == 0) return "missing contract id";
+            if (!long.TryParse(ds.args[0], out _)) return "invalid contract id";
+            var found = FindContract(ds.args);
+            if (found == null) return "contract not found";
+            if (found.ContractState != Contract.State.Offered)
+                return "contract not in Offered state";
+            found.Decline();
+            return 0;
+        }
+
+        [TelemetryAPI("contracts.cancel",
+            "Cancel an Active contract — forfeits work in progress; only valid for Active",
+            AlwaysEvaluable = true,
+            IsAction = true,
+            Category = "career",
+            ReturnType = "object",
+            Params = "long contractId")]
+        object Cancel(DataSources ds)
+        {
+            if (ds.args == null || ds.args.Count == 0) return "missing contract id";
+            if (!long.TryParse(ds.args[0], out _)) return "invalid contract id";
+            var found = FindContract(ds.args);
+            if (found == null) return "contract not found";
+            if (found.ContractState != Contract.State.Active)
+                return "contract not in Active state";
+            found.Cancel();
+            return 0;
+        }
+    }
+}

--- a/Telemachus/src/CurrencyModifiers.cs
+++ b/Telemachus/src/CurrencyModifiers.cs
@@ -1,0 +1,34 @@
+namespace Telemachus
+{
+    // Applies KSP's CurrencyModifierQuery against a nominal cost so the
+    // reported value matches what the player will actually be charged
+    // after active strategies / mod effects have voted. KSP's
+    // {Funding,ResearchAndDevelopment,Reputation}.Add* methods apply the
+    // mutation BEFORE firing OnCurrencyModifierQuery, so consumers can't
+    // adjust the deduction by listening — they have to pre-query the
+    // modifier separately, then pass the adjusted value to the Add call.
+    // This helper provides that pre-query step in a single line.
+    internal static class CurrencyModifiers
+    {
+        public static float Funds(float nominal, TransactionReasons reason)
+        {
+            var q = new CurrencyModifierQuery(reason, nominal, 0f, 0f);
+            GameEvents.Modifiers.OnCurrencyModifierQuery.Fire(q);
+            return q.GetTotal(Currency.Funds);
+        }
+
+        public static float Science(float nominal, TransactionReasons reason)
+        {
+            var q = new CurrencyModifierQuery(reason, 0f, nominal, 0f);
+            GameEvents.Modifiers.OnCurrencyModifierQuery.Fire(q);
+            return q.GetTotal(Currency.Science);
+        }
+
+        public static float Reputation(float nominal, TransactionReasons reason)
+        {
+            var q = new CurrencyModifierQuery(reason, 0f, 0f, nominal);
+            GameEvents.Modifiers.OnCurrencyModifierQuery.Fire(q);
+            return q.GetTotal(Currency.Reputation);
+        }
+    }
+}

--- a/Telemachus/src/KSPAPIBase.cs
+++ b/Telemachus/src/KSPAPIBase.cs
@@ -26,6 +26,12 @@ namespace Telemachus
             APIHandlers.Add(new ScienceCareerDataLinkHandler(formatters));
             APIHandlers.Add(new TimeWarpDataLinkHandler(formatters));
             APIHandlers.Add(new TargetDataLinkHandler(formatters));
+            APIHandlers.Add(new TechTreeDataLinkHandler(formatters));
+            APIHandlers.Add(new KscDataLinkHandler(formatters));
+            APIHandlers.Add(new ScienceInstrumentsDataLinkHandler(formatters));
+            APIHandlers.Add(new ContractsDataLinkHandler(formatters));
+            APIHandlers.Add(new LaunchDataLinkHandler(formatters));
+            APIHandlers.Add(new ActionGroupBindingsDataLinkHandler(formatters));
 
             APIHandlers.Add(new CompoundDataLinkHandler(
                 new List<DataLinkHandler> {

--- a/Telemachus/src/KSPAPIBase.cs
+++ b/Telemachus/src/KSPAPIBase.cs
@@ -32,6 +32,7 @@ namespace Telemachus
             APIHandlers.Add(new ContractsDataLinkHandler(formatters));
             APIHandlers.Add(new LaunchDataLinkHandler(formatters));
             APIHandlers.Add(new ActionGroupBindingsDataLinkHandler(formatters));
+            APIHandlers.Add(new StrategiesDataLinkHandler(formatters));
 
             APIHandlers.Add(new CompoundDataLinkHandler(
                 new List<DataLinkHandler> {

--- a/Telemachus/src/KscDataLinkHandler.cs
+++ b/Telemachus/src/KscDataLinkHandler.cs
@@ -105,7 +105,7 @@ namespace Telemachus
         }
 
         [TelemetryAPI("kc.facilityLevels",
-            "Per-facility { level, max, upgradeFunds } for the 9 stock SC buildings",
+            "Per-facility { level, max, upgradeFunds, currentLevelText, nextLevelText } for the 9 stock SC buildings",
             AlwaysEvaluable = true,
             Plotable = false,
             Category = "ksc",
@@ -120,11 +120,15 @@ namespace Telemachus
                     var normalised = ScenarioUpgradeableFacilities.GetFacilityLevel(pair.Value);
                     var max = ScenarioUpgradeableFacilities.GetFacilityLevelCount(pair.Value);
                     var level = max > 0 ? (int)Math.Round(normalised * max) : 0;
+                    ReadLevelTexts(pair.Value, level, max,
+                        out var currentLevelText, out var nextLevelText);
                     result[pair.Key] = new Dictionary<string, object>
                     {
                         ["level"] = level,
                         ["max"] = max,
                         ["upgradeFunds"] = R4(ReadUpgradeFunds(pair.Value, level)),
+                        ["currentLevelText"] = currentLevelText,
+                        ["nextLevelText"] = nextLevelText,
                     };
                 }
                 catch (Exception)
@@ -134,6 +138,8 @@ namespace Telemachus
                         ["level"] = 0,
                         ["max"] = 0,
                         ["upgradeFunds"] = 0d,
+                        ["currentLevelText"] = string.Empty,
+                        ["nextLevelText"] = string.Empty,
                     };
                 }
             }
@@ -162,6 +168,40 @@ namespace Telemachus
             catch (Exception)
             {
                 return 0d;
+            }
+        }
+
+        // Pulls the human-facing description block KSP shows in the
+        // SpaceCenter upgrade dialog for the current tier and (if not yet
+        // at max) the next tier — multi-line text describing what the
+        // facility currently allows plus what the upgrade would unlock.
+        // The UpgradeableFacility instance lives in protoUpgradeables; in
+        // non-SC scenes facilityRefs may be empty, in which case we return
+        // empty strings rather than throwing.
+        private static void ReadLevelTexts(
+            string facilityId, int currentLevel, int max,
+            out string currentLevelText, out string nextLevelText)
+        {
+            currentLevelText = string.Empty;
+            nextLevelText = string.Empty;
+            try
+            {
+                var dict = ScenarioUpgradeableFacilities.protoUpgradeables;
+                if (dict == null) return;
+                if (!dict.TryGetValue(facilityId, out var proto) || proto == null) return;
+                if (proto.facilityRefs == null || proto.facilityRefs.Count == 0) return;
+                var fac = proto.facilityRefs[0];
+                if (fac == null) return;
+
+                currentLevelText = fac.GetLevelText(currentLevel) ?? string.Empty;
+                if (currentLevel < max)
+                {
+                    nextLevelText = fac.GetLevelText(currentLevel + 1) ?? string.Empty;
+                }
+            }
+            catch (Exception)
+            {
+                // Best-effort — leave both as empty strings.
             }
         }
 

--- a/Telemachus/src/KscDataLinkHandler.cs
+++ b/Telemachus/src/KscDataLinkHandler.cs
@@ -1,0 +1,436 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Telemachus
+{
+    /// <summary>Space Center state — building levels, parts catalogue, rosters, scene id. Keys are global (vessel param ignored).</summary>
+    public class KscDataLinkHandler : DataLinkHandler
+    {
+        public KscDataLinkHandler(FormatterProvider formatters)
+            : base(formatters) { }
+
+        // Stock subset — mods add more facilities. Case-insensitive so callers don't have to match the exact casing.
+        private static readonly Dictionary<string, string> Facilities =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["launchPad"] = "SpaceCenter/LaunchPad",
+                ["runway"] = "SpaceCenter/Runway",
+                ["vab"] = "SpaceCenter/VehicleAssemblyBuilding",
+                ["sph"] = "SpaceCenter/SpaceplaneHangar",
+                ["mission"] = "SpaceCenter/MissionControl",
+                ["tracking"] = "SpaceCenter/TrackingStation",
+                ["admin"] = "SpaceCenter/Administration",
+                ["rd"] = "SpaceCenter/ResearchAndDevelopment",
+                ["astronaut"] = "SpaceCenter/AstronautComplex",
+            };
+
+        private static double R4(double v)
+        {
+            if (double.IsNaN(v) || double.IsInfinity(v)) return v;
+            return Math.Round(v, 4);
+        }
+
+        [TelemetryAPI("kc.scene",
+            "Current KSP scene (Flight, SpaceCenter, Editor, TrackingStation, MainMenu, Other)",
+            Units = APIEntry.UnitType.STRING,
+            AlwaysEvaluable = true,
+            Category = "ksc",
+            ReturnType = "string")]
+        object Scene(DataSources ds)
+        {
+            switch (HighLogic.LoadedScene)
+            {
+                case GameScenes.FLIGHT: return "Flight";
+                case GameScenes.SPACECENTER: return "SpaceCenter";
+                case GameScenes.EDITOR: return "Editor";
+                case GameScenes.TRACKSTATION: return "TrackingStation";
+                case GameScenes.MAINMENU: return "MainMenu";
+                default: return "Other";
+            }
+        }
+
+        [TelemetryAPI("kc.partsAvailable",
+            "Number of parts purchasable under current tech",
+            AlwaysEvaluable = true,
+            Category = "ksc",
+            ReturnType = "int")]
+        object PartsAvailable(DataSources ds)
+        {
+            if (PartLoader.LoadedPartsList == null) return 0;
+            var count = 0;
+            foreach (var part in PartLoader.LoadedPartsList)
+            {
+                if (ResearchAndDevelopment.PartTechAvailable(part)) count++;
+            }
+            return count;
+        }
+
+        [TelemetryAPI("kc.launchSite",
+            "Active flight's launch site name",
+            Units = APIEntry.UnitType.STRING,
+            AlwaysEvaluable = true,
+            Category = "ksc",
+            ReturnType = "string")]
+        object LaunchSite(DataSources ds)
+        {
+            try { return FlightDriver.LaunchSiteName ?? string.Empty; }
+            catch (Exception) { return string.Empty; }
+        }
+
+        [TelemetryAPI("kc.padOccupied",
+            "True iff the active vessel is in PRELAUNCH situation",
+            AlwaysEvaluable = true,
+            Category = "ksc",
+            ReturnType = "bool")]
+        object PadOccupied(DataSources ds)
+        {
+            var vessel = ds.vessel;
+            if (vessel == null) return false;
+            return vessel.situation == Vessel.Situations.PRELAUNCH;
+        }
+
+        [TelemetryAPI("kc.padVesselTitle",
+            "Vessel name when on the pad; empty otherwise",
+            Units = APIEntry.UnitType.STRING,
+            AlwaysEvaluable = true,
+            Category = "ksc",
+            ReturnType = "string")]
+        object PadVesselTitle(DataSources ds)
+        {
+            var vessel = ds.vessel;
+            if (vessel == null) return string.Empty;
+            if (vessel.situation != Vessel.Situations.PRELAUNCH) return string.Empty;
+            return vessel.vesselName ?? string.Empty;
+        }
+
+        [TelemetryAPI("kc.facilityLevels",
+            "Per-facility { level, max, upgradeFunds } for the 9 stock SC buildings",
+            AlwaysEvaluable = true,
+            Plotable = false,
+            Category = "ksc",
+            ReturnType = "object")]
+        object FacilityLevels(DataSources ds)
+        {
+            var result = new Dictionary<string, object>();
+            foreach (var pair in Facilities)
+            {
+                try
+                {
+                    var normalised = ScenarioUpgradeableFacilities.GetFacilityLevel(pair.Value);
+                    var max = ScenarioUpgradeableFacilities.GetFacilityLevelCount(pair.Value);
+                    var level = max > 0 ? (int)Math.Round(normalised * max) : 0;
+                    result[pair.Key] = new Dictionary<string, object>
+                    {
+                        ["level"] = level,
+                        ["max"] = max,
+                        ["upgradeFunds"] = R4(ReadUpgradeFunds(pair.Value, level)),
+                    };
+                }
+                catch (Exception)
+                {
+                    result[pair.Key] = new Dictionary<string, object>
+                    {
+                        ["level"] = 0,
+                        ["max"] = 0,
+                        ["upgradeFunds"] = 0d,
+                    };
+                }
+            }
+            return result;
+        }
+
+        // Reads UpgradeLevels[FacilityLevel + 1].levelCost via protoUpgradeables; returns 0 outside SC / at max / pre-init.
+        private static double ReadUpgradeFunds(string facilityId, int currentLevel)
+        {
+            try
+            {
+                var dict = ScenarioUpgradeableFacilities.protoUpgradeables;
+                if (dict == null) return 0d;
+                if (!dict.TryGetValue(facilityId, out var proto) || proto == null)
+                    return 0d;
+                if (proto.facilityRefs == null || proto.facilityRefs.Count == 0)
+                    return 0d;
+                var fac = proto.facilityRefs[0];
+                if (fac == null) return 0d;
+                var levels = fac.UpgradeLevels;
+                if (levels == null) return 0d;
+                var nextIdx = fac.FacilityLevel + 1;
+                if (nextIdx >= levels.Length) return 0d;
+                return levels[nextIdx]?.levelCost ?? 0d;
+            }
+            catch (Exception)
+            {
+                return 0d;
+            }
+        }
+
+        [TelemetryAPI("kc.crewRoster",
+            "Whole-program kerbal roster — name, trait, type, gender, experience, experienceLevel, " +
+            "courage, stupidity, isBadass, veteran, careerFlights, careerEntries, " +
+            "currentVesselId, currentVesselName, available, unavailableReason",
+            AlwaysEvaluable = true,
+            Plotable = false,
+            Category = "ksc",
+            ReturnType = "object")]
+        object CrewRoster(DataSources ds)
+        {
+            var result = new List<Dictionary<string, object>>();
+            var roster = HighLogic.CurrentGame?.CrewRoster;
+            if (roster == null) return result;
+
+            // Pre-built name→vessel map keeps the per-kerbal walk O(K); empty in non-flight scenes (FlightGlobals.Vessels empty).
+            var crewVesselByName = new Dictionary<string, KeyValuePair<string, string>>(
+                StringComparer.Ordinal);
+            var vessels = FlightGlobals.Vessels;
+            if (vessels != null)
+            {
+                foreach (var vessel in vessels)
+                {
+                    if (vessel == null) continue;
+                    var vid = vessel.id.ToString();
+                    var vname = vessel.GetDisplayName() ?? vessel.vesselName ?? string.Empty;
+                    var crew = vessel.GetVesselCrew();
+                    if (crew == null) continue;
+                    foreach (var member in crew)
+                    {
+                        if (member?.name == null) continue;
+                        crewVesselByName[member.name] =
+                            new KeyValuePair<string, string>(vid, vname);
+                    }
+                }
+            }
+
+            foreach (var kerbal in roster.Crew)
+            {
+                if (kerbal == null) continue;
+                var status = kerbal.rosterStatus.ToString();
+                var available = kerbal.rosterStatus == ProtoCrewMember.RosterStatus.Available;
+                var vesselId = string.Empty;
+                var vesselName = string.Empty;
+                if (kerbal.name != null &&
+                    crewVesselByName.TryGetValue(kerbal.name, out var pair))
+                {
+                    vesselId = pair.Key;
+                    vesselName = pair.Value;
+                }
+
+                int careerFlights = 0;
+                int careerEntries = 0;
+                if (kerbal.careerLog != null)
+                {
+                    careerFlights = kerbal.careerLog.Flight;
+                    careerEntries = kerbal.careerLog.Count;
+                }
+
+                result.Add(new Dictionary<string, object>
+                {
+                    ["name"] = kerbal.name ?? string.Empty,
+                    ["trait"] = kerbal.trait ?? string.Empty,
+                    ["type"] = kerbal.type.ToString(),
+                    ["gender"] = kerbal.gender.ToString(),
+                    ["experience"] = R4(kerbal.experience),
+                    ["experienceLevel"] = kerbal.experienceLevel,
+                    ["courage"] = R4(kerbal.courage),
+                    ["stupidity"] = R4(kerbal.stupidity),
+                    ["isBadass"] = kerbal.isBadass,
+                    ["veteran"] = kerbal.veteran,
+                    ["careerFlights"] = careerFlights,
+                    ["careerEntries"] = careerEntries,
+                    ["currentVesselId"] = vesselId,
+                    ["currentVesselName"] = vesselName,
+                    ["available"] = available,
+                    ["unavailableReason"] = available ? string.Empty : status,
+                });
+            }
+            return result;
+        }
+
+        [TelemetryAPI("kc.savedShips",
+            "Saved craft files in VAB+SPH — name, partCount, totalMass, facility, requiresFunds, missingParts",
+            AlwaysEvaluable = true,
+            Plotable = false,
+            Category = "ksc",
+            ReturnType = "object")]
+        object SavedShips(DataSources ds)
+        {
+            var result = new List<Dictionary<string, object>>();
+            var saveFolder = HighLogic.SaveFolder;
+            if (string.IsNullOrEmpty(saveFolder)) return result;
+            var rootPath = Path.Combine(KSPUtil.ApplicationRootPath, "saves");
+            rootPath = Path.Combine(rootPath, saveFolder);
+            rootPath = Path.Combine(rootPath, "Ships");
+            if (!Directory.Exists(rootPath)) return result;
+
+            foreach (var facility in new[] { "VAB", "SPH" })
+            {
+                var dir = Path.Combine(rootPath, facility);
+                if (!Directory.Exists(dir)) continue;
+                foreach (var craftPath in Directory.GetFiles(dir, "*.craft"))
+                {
+                    result.Add(SerialiseCraftFile(craftPath, facility));
+                }
+            }
+            return result;
+        }
+
+        private static Dictionary<string, object> SerialiseCraftFile(
+            string craftPath, string facility)
+        {
+            var name = Path.GetFileNameWithoutExtension(craftPath);
+            int partCount = 0;
+            double totalMass = 0;
+            double requiresFunds = 0;
+            var missing = new HashSet<string>();
+
+            try
+            {
+                var node = ConfigNode.Load(craftPath);
+                if (node != null)
+                {
+                    var partNodes = node.GetNodes("PART");
+                    partCount = partNodes.Length;
+                    foreach (var p in partNodes)
+                    {
+                        WalkPart(p, ref totalMass, ref requiresFunds, missing);
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // Corrupt or in-progress .craft — surface partial parse rather than dropping the file.
+            }
+
+            return new Dictionary<string, object>
+            {
+                ["name"] = name,
+                ["partCount"] = partCount,
+                ["totalMass"] = R4(totalMass),
+                ["facility"] = facility,
+                ["requiresFunds"] = R4(requiresFunds),
+                ["missingParts"] = new List<string>(missing),
+            };
+        }
+
+        // .craft writes `<partName>_<flightId>`; strip only the trailing _<digits> so modded names with legit underscores survive.
+        private static string ExtractPartName(ConfigNode partNode)
+        {
+            var raw = partNode.HasValue("name")
+                ? partNode.GetValue("name")
+                : partNode.HasValue("part")
+                    ? partNode.GetValue("part")
+                    : null;
+            if (string.IsNullOrEmpty(raw)) return null;
+            var underscore = raw.LastIndexOf('_');
+            if (underscore <= 0) return raw;
+            for (var i = underscore + 1; i < raw.Length; i++)
+            {
+                if (raw[i] < '0' || raw[i] > '9') return raw;
+            }
+            return raw.Substring(0, underscore);
+        }
+
+        private static void WalkPart(ConfigNode partNode,
+            ref double totalMass, ref double requiresFunds,
+            HashSet<string> missing)
+        {
+            var partName = ExtractPartName(partNode);
+            if (partNode.HasValue("mass") &&
+                double.TryParse(partNode.GetValue("mass"), out var dryMass))
+                totalMass += dryMass;
+
+            AvailablePart available = null;
+            if (!string.IsNullOrEmpty(partName) && PartLoader.LoadedPartsList != null)
+            {
+                foreach (var ap in PartLoader.LoadedPartsList)
+                {
+                    if (ap != null && ap.name == partName)
+                    {
+                        available = ap;
+                        break;
+                    }
+                }
+            }
+
+            if (available == null)
+            {
+                if (!string.IsNullOrEmpty(partName)) missing.Add(partName);
+            }
+            else
+            {
+                requiresFunds += available.cost;
+                if (ResearchAndDevelopment.Instance != null &&
+                    !ResearchAndDevelopment.PartTechAvailable(available))
+                    missing.Add(partName);
+            }
+
+            foreach (var resNode in partNode.GetNodes("RESOURCE"))
+            {
+                if (!resNode.HasValue("name")) continue;
+                if (!resNode.HasValue("amount")) continue;
+                if (!double.TryParse(resNode.GetValue("amount"), out var amount)) continue;
+                var def = PartResourceLibrary.Instance?.GetDefinition(
+                    resNode.GetValue("name"));
+                if (def == null) continue;
+                totalMass += amount * def.density;
+                requiresFunds += amount * def.unitCost;
+            }
+        }
+
+        [TelemetryAPI("kc.upgradeFacility",
+            "Upgrade a SC facility by short name (launchPad, vab, sph, …)",
+            AlwaysEvaluable = true,
+            IsAction = true,
+            Category = "ksc",
+            ReturnType = "object",
+            Params = "string facilityShortName")]
+        object UpgradeFacility(DataSources ds)
+        {
+            if (ds.args == null || ds.args.Count == 0) return "missing facility id";
+            var shortName = ds.args[0];
+            if (string.IsNullOrEmpty(shortName)) return "missing facility id";
+            if (!Facilities.TryGetValue(shortName, out var facilityId))
+                return "unknown facility";
+
+            // Programmatic path (SetLevel + AddFunds) — refuse outside SC so a stray call mid-flight can't upgrade.
+            if (HighLogic.LoadedScene != GameScenes.SPACECENTER)
+                return "not in Space Center scene";
+
+            try
+            {
+                var dict = ScenarioUpgradeableFacilities.protoUpgradeables;
+                if (dict == null) return "no upgradeables";
+                if (!dict.TryGetValue(facilityId, out var proto) || proto == null)
+                    return "facility not found";
+                if (proto.facilityRefs == null || proto.facilityRefs.Count == 0)
+                    return "facility refs empty";
+                var fac = proto.facilityRefs[0];
+                if (fac == null) return "facility ref null";
+                var levels = fac.UpgradeLevels;
+                if (levels == null) return "no upgrade levels";
+                var nextIdx = fac.FacilityLevel + 1;
+                if (nextIdx >= levels.Length) return "already at max";
+                var cost = (double)(levels[nextIdx]?.levelCost ?? 0f);
+                if (Funding.Instance != null && Funding.Instance.Funds < cost)
+                    return "insufficient funds";
+
+                // SetLevel routes through OnUpgradeableObjLevelChange so persistence + scene state stay in sync. Funds deduction is separate — KSP only auto-charges through the SC UI.
+                foreach (var refFac in proto.facilityRefs)
+                {
+                    refFac?.SetLevel(nextIdx);
+                }
+                if (Funding.Instance != null && cost > 0d)
+                {
+                    Funding.Instance.AddFunds(
+                        -cost,
+                        TransactionReasons.StructureConstruction);
+                }
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                return "upgrade failed: " + ex.Message;
+            }
+        }
+    }
+}

--- a/Telemachus/src/KscDataLinkHandler.cs
+++ b/Telemachus/src/KscDataLinkHandler.cs
@@ -105,7 +105,7 @@ namespace Telemachus
         }
 
         [TelemetryAPI("kc.facilityLevels",
-            "Per-facility { level, max, upgradeFunds, currentLevelText, nextLevelText } for the 9 stock SC buildings",
+            "Per-facility { level, max, upgradeFunds, upgradeFundsEffective (post strategy modifier), currentLevelText, nextLevelText } for the 9 stock SC buildings",
             AlwaysEvaluable = true,
             Plotable = false,
             Category = "ksc",
@@ -122,11 +122,16 @@ namespace Telemachus
                     var level = max > 0 ? (int)Math.Round(normalised * max) : 0;
                     ReadLevelTexts(pair.Value, level, max,
                         out var currentLevelText, out var nextLevelText);
+                    var upgradeFunds = (float)ReadUpgradeFunds(pair.Value, level);
+                    var upgradeFundsEffective = upgradeFunds > 0f
+                        ? CurrencyModifiers.Funds(upgradeFunds, TransactionReasons.StructureConstruction)
+                        : 0f;
                     result[pair.Key] = new Dictionary<string, object>
                     {
                         ["level"] = level,
                         ["max"] = max,
-                        ["upgradeFunds"] = R4(ReadUpgradeFunds(pair.Value, level)),
+                        ["upgradeFunds"] = R4(upgradeFunds),
+                        ["upgradeFundsEffective"] = R4(upgradeFundsEffective),
                         ["currentLevelText"] = currentLevelText,
                         ["nextLevelText"] = nextLevelText,
                     };
@@ -138,6 +143,7 @@ namespace Telemachus
                         ["level"] = 0,
                         ["max"] = 0,
                         ["upgradeFunds"] = 0d,
+                        ["upgradeFundsEffective"] = 0d,
                         ["currentLevelText"] = string.Empty,
                         ["nextLevelText"] = string.Empty,
                     };
@@ -287,7 +293,7 @@ namespace Telemachus
         }
 
         [TelemetryAPI("kc.savedShips",
-            "Saved craft files in VAB+SPH — name, partCount, totalMass, facility, requiresFunds, missingParts",
+            "Saved craft files in VAB+SPH — name, partCount, totalMass, facility, requiresFunds, requiresFundsEffective (post strategy modifier), missingParts",
             AlwaysEvaluable = true,
             Plotable = false,
             Category = "ksc",
@@ -341,6 +347,9 @@ namespace Telemachus
                 // Corrupt or in-progress .craft — surface partial parse rather than dropping the file.
             }
 
+            var requiresFundsEffective = requiresFunds > 0f
+                ? CurrencyModifiers.Funds((float)requiresFunds, TransactionReasons.VesselRollout)
+                : 0f;
             return new Dictionary<string, object>
             {
                 ["name"] = name,
@@ -348,6 +357,7 @@ namespace Telemachus
                 ["totalMass"] = R4(totalMass),
                 ["facility"] = facility,
                 ["requiresFunds"] = R4(requiresFunds),
+                ["requiresFundsEffective"] = R4(requiresFundsEffective),
                 ["missingParts"] = new List<string>(missing),
             };
         }

--- a/Telemachus/src/LaunchDataLinkHandler.cs
+++ b/Telemachus/src/LaunchDataLinkHandler.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Telemachus
+{
+    /// <summary>Launch / recover / revert verbs — scene-coupled, run on the main thread via the base class's IsAction auto-defer.</summary>
+    public class LaunchDataLinkHandler : DataLinkHandler
+    {
+        public LaunchDataLinkHandler(FormatterProvider formatters)
+            : base(formatters) { }
+
+        [TelemetryAPI("ksp.launch",
+            "Load a saved craft to the chosen pad (shipName, facility, site, crewSemicolons). " +
+            "Refuses outside SC/Editor, refuses if an active vessel exists.",
+            AlwaysEvaluable = true,
+            IsAction = true,
+            Category = "launch",
+            ReturnType = "object",
+            Params = "string shipName, string facility, string site, string crewSemicolons")]
+        object Launch(DataSources ds)
+        {
+            var args = ds.args;
+            if (args == null || args.Count < 3)
+                return "expected [shipName,facility,site,crew]";
+            var shipName = args[0];
+            // Saves directory uses VAB / SPH uppercase; normalise so callers don't have to match case on case-sensitive filesystems.
+            var facility = args[1]?.ToUpperInvariant() ?? string.Empty;
+            var site = args[2];
+            var crewArg = args.Count >= 4 ? args[3] : string.Empty;
+
+            if (string.IsNullOrEmpty(shipName)) return "missing ship name";
+
+            if (HighLogic.LoadedScene != GameScenes.SPACECENTER &&
+                HighLogic.LoadedScene != GameScenes.EDITOR)
+                return "not in a launchable scene";
+
+            // Launching while an unrecovered ActiveVessel exists wedges KSP — frozen Flight scene with maxed UT counters.
+            if (FlightGlobals.ActiveVessel != null)
+                return "active vessel exists — recover or revert before launching";
+
+            var saveFolder = HighLogic.SaveFolder;
+            if (string.IsNullOrEmpty(saveFolder)) return "no active save";
+            var craftPath = Path.Combine(KSPUtil.ApplicationRootPath, "saves");
+            craftPath = Path.Combine(craftPath, saveFolder);
+            craftPath = Path.Combine(craftPath, "Ships");
+            craftPath = Path.Combine(craftPath, facility);
+            craftPath = Path.Combine(craftPath, shipName + ".craft");
+            if (!File.Exists(craftPath)) return "craft file not found";
+
+            // Crew uses ';' delimiter — bracket-form action args already split on ','.
+            var crewNames = string.IsNullOrEmpty(crewArg)
+                ? Array.Empty<string>()
+                : crewArg.Split(';');
+
+            // Always build manifest from .craft — passing null NREs inside setStartupNewVessel and frozen-HUDs Flight.
+            VesselCrewManifest manifest;
+            try
+            {
+                var craftNode = ConfigNode.Load(craftPath);
+                if (craftNode == null) return "could not load craft node";
+                manifest = VesselCrewManifest.FromConfigNode(craftNode);
+                if (crewNames.Length > 0)
+                {
+                    AssignCrew(manifest, crewNames);
+                }
+            }
+            catch (Exception ex)
+            {
+                return "manifest build failed: " + ex.Message;
+            }
+
+            var flagUrl = HighLogic.CurrentGame?.flagURL ?? "Squad/Flags/default";
+            FlightDriver.StartWithNewLaunch(craftPath, flagUrl, site, manifest);
+            return 0;
+        }
+
+        private static void AssignCrew(VesselCrewManifest manifest,
+            string[] crewNames)
+        {
+            if (manifest == null || crewNames == null) return;
+            var roster = HighLogic.CurrentGame?.CrewRoster;
+            if (roster == null) return;
+
+            var queue = new Queue<string>(crewNames);
+            foreach (var partManifest in manifest.PartManifests)
+            {
+                if (partManifest == null) continue;
+                if (queue.Count == 0) return;
+                var existing = partManifest.GetPartCrew();
+                if (existing == null) continue;
+                for (var i = 0; i < existing.Length && queue.Count > 0; i++)
+                {
+                    if (existing[i] != null) continue;
+                    var kerbalName = queue.Dequeue();
+                    if (string.IsNullOrEmpty(kerbalName)) continue;
+                    var kerbal = roster[kerbalName];
+                    if (kerbal == null) continue;
+                    if (kerbal.rosterStatus !=
+                        ProtoCrewMember.RosterStatus.Available) continue;
+                    partManifest.AddCrewToSeat(kerbal, i);
+                }
+            }
+        }
+
+        [TelemetryAPI("ksp.recover",
+            "Recover the active vessel — only valid in PRELAUNCH / LANDED / SPLASHED",
+            IsAction = true,
+            Category = "launch",
+            ReturnType = "object")]
+        object Recover(DataSources ds)
+        {
+            var vessel = ds.vessel;
+            if (vessel == null) return "no active vessel";
+            var s = vessel.situation;
+            if (s != Vessel.Situations.PRELAUNCH &&
+                s != Vessel.Situations.LANDED &&
+                s != Vessel.Situations.SPLASHED)
+                return "vessel not in a recoverable state";
+
+            // Fire the upper-case request event — lowercase onVesselRecovered is post-recovery notification.
+            GameEvents.OnVesselRecoveryRequested.Fire(vessel);
+            return 0;
+        }
+
+        [TelemetryAPI("ksp.revertToEditor",
+            "Revert flight back to the named editor scene (vab|sph)",
+            IsAction = true,
+            Category = "launch",
+            ReturnType = "object",
+            Params = "string editor")]
+        object RevertToEditor(DataSources ds)
+        {
+            if (ds.args == null || ds.args.Count == 0) return "expected [vab|sph]";
+            var which = ds.args[0];
+            EditorFacility facility;
+            if (string.Equals(which, "vab", StringComparison.OrdinalIgnoreCase))
+                facility = EditorFacility.VAB;
+            else if (string.Equals(which, "sph", StringComparison.OrdinalIgnoreCase))
+                facility = EditorFacility.SPH;
+            else return "expected vab or sph";
+
+            if (HighLogic.LoadedScene != GameScenes.FLIGHT)
+                return "not in flight";
+
+            FlightDriver.RevertToPrelaunch(facility);
+            return 0;
+        }
+
+        [TelemetryAPI("ksp.revertToLaunch",
+            "Revert flight to the just-launched state (vessel back on pad, " +
+            "PRELAUNCH situation). Same as the Flight Results dialog's " +
+            "'Revert to Launch' button. Refuses outside Flight scene or " +
+            "when the post-init snapshot isn't available.",
+            AlwaysEvaluable = true,
+            IsAction = true,
+            Category = "launch",
+            ReturnType = "object")]
+        object RevertToLaunch(DataSources ds)
+        {
+            if (HighLogic.LoadedScene != GameScenes.FLIGHT)
+                return "not in flight";
+            if (!FlightDriver.CanRevertToPostInit)
+                return "revert-to-launch not available (no post-init snapshot)";
+            FlightDriver.RevertToLaunch();
+            return 0;
+        }
+
+        [TelemetryAPI("ksp.toSpaceCenter",
+            "Switch to the Space Center scene. Mirrors the Flight Results " +
+            "dialog's 'Space Center' button.",
+            AlwaysEvaluable = true,
+            IsAction = true,
+            Category = "launch",
+            ReturnType = "object")]
+        object ToSpaceCenter(DataSources ds)
+        {
+            if (HighLogic.LoadedScene == GameScenes.SPACECENTER) return 0;
+            HighLogic.LoadScene(GameScenes.SPACECENTER);
+            return 0;
+        }
+
+        [TelemetryAPI("ksp.toTrackingStation",
+            "Switch to the Tracking Station scene. Mirrors the Flight " +
+            "Results dialog's 'Tracking Station' button.",
+            AlwaysEvaluable = true,
+            IsAction = true,
+            Category = "launch",
+            ReturnType = "object")]
+        object ToTrackingStation(DataSources ds)
+        {
+            if (HighLogic.LoadedScene == GameScenes.TRACKSTATION) return 0;
+            HighLogic.LoadScene(GameScenes.TRACKSTATION);
+            return 0;
+        }
+
+        [TelemetryAPI("ksp.canRevert",
+            "Whether any revert path is available right now (post-init " +
+            "snapshot OR prelaunch snapshot). Mirrors FlightDriver.CanRevert.",
+            AlwaysEvaluable = true,
+            Category = "launch",
+            ReturnType = "bool")]
+        object CanRevert(DataSources ds) => FlightDriver.CanRevert;
+
+        [TelemetryAPI("ksp.canRevertToLaunch",
+            "Whether ksp.revertToLaunch would currently succeed " +
+            "(FlightDriver.CanRevertToPostInit). Useful for graying " +
+            "out the revert-to-launch UI when the snapshot isn't available.",
+            AlwaysEvaluable = true,
+            Category = "launch",
+            ReturnType = "bool")]
+        object CanRevertToLaunch(DataSources ds) => FlightDriver.CanRevertToPostInit;
+
+        [TelemetryAPI("ksp.canRevertToEditor",
+            "Whether ksp.revertToEditor would currently succeed " +
+            "(FlightDriver.CanRevertToPrelaunch). Useful for graying " +
+            "out the revert-to-editor UI when the snapshot isn't available.",
+            AlwaysEvaluable = true,
+            Category = "launch",
+            ReturnType = "bool")]
+        object CanRevertToEditor(DataSources ds) => FlightDriver.CanRevertToPrelaunch;
+    }
+}

--- a/Telemachus/src/ScienceInstrumentsDataLinkHandler.cs
+++ b/Telemachus/src/ScienceInstrumentsDataLinkHandler.cs
@@ -1,0 +1,304 @@
+using System;
+using System.Collections.Generic;
+
+namespace Telemachus
+{
+    /// <summary>Per-instrument ModuleScienceExperiment state + deploy/transmit/dump/reset verbs. Keys are per-vessel.</summary>
+    public class ScienceInstrumentsDataLinkHandler : DataLinkHandler
+    {
+        public ScienceInstrumentsDataLinkHandler(FormatterProvider formatters)
+            : base(formatters) { }
+
+        private static double R4(double v)
+        {
+            if (double.IsNaN(v) || double.IsInfinity(v)) return v;
+            return Math.Round(v, 4);
+        }
+
+        // SubjectID shape `<expId>@<body><situation><biome>` has no separator — segment by recognising stock situation tokens.
+        private static readonly string[] KnownSituations = {
+            "InSpaceLow", "InSpaceHigh",
+            "FlyingLow", "FlyingHigh",
+            "SrfLanded", "SrfSplashed",
+        };
+
+        private static void ParseSubjectId(string subjectId,
+            out string situation, out string biome)
+        {
+            situation = string.Empty;
+            biome = string.Empty;
+            if (string.IsNullOrEmpty(subjectId)) return;
+            var atIdx = subjectId.IndexOf('@');
+            if (atIdx < 0 || atIdx >= subjectId.Length - 1) return;
+
+            var tail = subjectId.Substring(atIdx + 1);
+            foreach (var sit in KnownSituations)
+            {
+                var sitIdx = tail.IndexOf(sit, StringComparison.Ordinal);
+                if (sitIdx <= 0) continue;
+                situation = sit;
+                if (sitIdx + sit.Length < tail.Length)
+                    biome = tail.Substring(sitIdx + sit.Length);
+                return;
+            }
+        }
+
+        [TelemetryAPI("sci.instruments",
+            "Per-instrument state on the active vessel (partId, partTitle, expId, deployed, hasData, rerunnable, inoperable)",
+            Plotable = false,
+            Category = "science",
+            ReturnType = "object")]
+        object Instruments(DataSources ds)
+        {
+            var result = new List<Dictionary<string, object>>();
+            var vessel = ds.vessel;
+            if (vessel == null || vessel.parts == null) return result;
+
+            foreach (var part in vessel.parts)
+            {
+                if (part == null || part.Modules == null) continue;
+                foreach (var module in part.Modules)
+                {
+                    if (!(module is ModuleScienceExperiment exp)) continue;
+                    var data = exp.GetData();
+                    var hasData = data != null && data.Length > 0;
+
+                    result.Add(new Dictionary<string, object>
+                    {
+                        ["partId"] = part.flightID,
+                        ["partTitle"] = part.partInfo != null
+                            ? part.partInfo.title
+                            : part.name,
+                        ["expId"] = exp.experimentID ?? string.Empty,
+                        ["deployed"] = exp.Deployed,
+                        ["hasData"] = hasData,
+                        ["rerunnable"] = exp.rerunnable,
+                        ["inoperable"] = exp.Inoperable,
+                    });
+                }
+            }
+            return result;
+        }
+
+        [TelemetryAPI("sci.experimentBreakdown",
+            "Per-stored-data detail on the active vessel — subjectId / biome / situation / mits / transmit values / remaining potential",
+            Plotable = false,
+            Category = "science",
+            ReturnType = "object")]
+        object ExperimentBreakdown(DataSources ds)
+        {
+            var result = new List<Dictionary<string, object>>();
+            var vessel = ds.vessel;
+            if (vessel == null || vessel.parts == null) return result;
+
+            foreach (var part in vessel.parts)
+            {
+                if (part == null || part.Modules == null) continue;
+                foreach (var module in part.Modules)
+                {
+                    if (!(module is IScienceDataContainer container)) continue;
+                    var data = container.GetData();
+                    if (data == null) continue;
+
+                    foreach (var d in data)
+                    {
+                        if (d == null) continue;
+                        var entry = new Dictionary<string, object>
+                        {
+                            ["subjectId"] = d.subjectID ?? string.Empty,
+                            ["expTitle"] = d.title ?? string.Empty,
+                            ["dataMits"] = R4(d.dataAmount),
+                            ["baseTransmitValue"] = R4(d.baseTransmitValue),
+                            ["transmitBonus"] = R4(d.transmitBonus),
+                        };
+
+                        string biome = string.Empty;
+                        string situation = string.Empty;
+                        float subjectScience = 0f;
+                        float subjectCap = 0f;
+
+                        if (ResearchAndDevelopment.Instance != null &&
+                            !string.IsNullOrEmpty(d.subjectID))
+                        {
+                            var subject = ResearchAndDevelopment
+                                .GetSubjectByID(d.subjectID);
+                            if (subject != null)
+                            {
+                                subjectScience = subject.science;
+                                subjectCap = subject.scienceCap;
+                            }
+                            ParseSubjectId(d.subjectID, out situation, out biome);
+                        }
+
+                        entry["biome"] = biome;
+                        entry["situation"] = situation;
+                        entry["subjectScience"] = R4(subjectScience);
+                        entry["subjectScienceCap"] = R4(subjectCap);
+                        entry["remainingPotential"] =
+                            R4(Math.Max(0f, subjectCap - subjectScience));
+                        result.Add(entry);
+                    }
+                }
+            }
+            return result;
+        }
+
+        [TelemetryAPI("sci.canTransmitTotal",
+            "Total dataAmount across all stored ScienceData on the active vessel",
+            Category = "science",
+            ReturnType = "double")]
+        object CanTransmitTotal(DataSources ds) => DataAmountTotal(ds.vessel);
+
+        [TelemetryAPI("sci.canRecoverTotal",
+            "Total dataAmount across all stored ScienceData on the active vessel (alias of canTransmitTotal — separate key in case Phase 4 formulas diverge)",
+            Category = "science",
+            ReturnType = "double")]
+        object CanRecoverTotal(DataSources ds) => DataAmountTotal(ds.vessel);
+
+        private static double DataAmountTotal(Vessel vessel)
+        {
+            if (vessel == null || vessel.parts == null) return 0d;
+            float total = 0f;
+            foreach (var part in vessel.parts)
+            {
+                if (part == null || part.Modules == null) continue;
+                foreach (var module in part.Modules)
+                {
+                    if (!(module is IScienceDataContainer container)) continue;
+                    var data = container.GetData();
+                    if (data == null) continue;
+                    foreach (var d in data)
+                    {
+                        if (d != null) total += d.dataAmount;
+                    }
+                }
+            }
+            return R4(total);
+        }
+
+        private static ModuleScienceExperiment FindExperimentByPartId(
+            Vessel vessel, IList<string> args)
+        {
+            if (vessel == null || vessel.parts == null) return null;
+            if (args == null || args.Count == 0) return null;
+            if (!uint.TryParse(args[0], out var partId)) return null;
+
+            foreach (var part in vessel.parts)
+            {
+                if (part == null || part.flightID != partId) continue;
+                foreach (var module in part.Modules)
+                {
+                    if (module is ModuleScienceExperiment exp) return exp;
+                }
+                return null;
+            }
+            return null;
+        }
+
+        [TelemetryAPI("sci.deploy",
+            "Run an experiment by part flightID (no result dialog — direct data capture)",
+            IsAction = true,
+            Category = "science",
+            ReturnType = "object",
+            Params = "uint partId")]
+        object Deploy(DataSources ds)
+        {
+            var exp = FindExperimentByPartId(ds.vessel, ds.args);
+            if (exp == null) return "instrument not found";
+            if (exp.Inoperable) return "instrument inoperable";
+            if (exp.Deployed) return 0; // already deployed — idempotent
+
+            // Reflect into private gatherData(showDialog: false) — DeployExperiment() goes through the dialog branch. Fall back to DeployExperiment() on KSP version drift.
+            try
+            {
+                var method = typeof(ModuleScienceExperiment).GetMethod(
+                    "gatherData",
+                    System.Reflection.BindingFlags.NonPublic |
+                    System.Reflection.BindingFlags.Instance);
+                if (method == null)
+                {
+                    exp.DeployExperiment();
+                    return 0;
+                }
+                var coroutine = method.Invoke(exp, new object[] { false })
+                    as System.Collections.IEnumerator;
+                if (coroutine != null)
+                {
+                    exp.StartCoroutine(coroutine);
+                }
+                else
+                {
+                    exp.DeployExperiment();
+                }
+            }
+            catch (Exception ex)
+            {
+                UnityEngine.Debug.LogError(
+                    "[Telemachus] sci.deploy non-dialog path failed: " + ex);
+                try { exp.DeployExperiment(); } catch { /* best-effort */ }
+            }
+            return 0;
+        }
+
+        [TelemetryAPI("sci.transmit",
+            "Transmit stored data on the part via the active vessel's best transmitter",
+            IsAction = true,
+            Category = "science",
+            ReturnType = "object",
+            Params = "uint partId")]
+        object Transmit(DataSources ds)
+        {
+            var exp = FindExperimentByPartId(ds.vessel, ds.args);
+            if (exp == null) return "instrument not found";
+
+            var data = exp.GetData();
+            if (data == null || data.Length == 0) return "no data to transmit";
+
+            var transmitter = ScienceUtil.GetBestTransmitter(ds.vessel);
+            if (transmitter == null) return "no transmitter available";
+
+            var list = new List<ScienceData>(data);
+            transmitter.TransmitData(list);
+            foreach (var d in data)
+            {
+                if (d != null) exp.DumpData(d);
+            }
+            return 0;
+        }
+
+        [TelemetryAPI("sci.dump",
+            "Discard all stored data on the part without transmitting",
+            IsAction = true,
+            Category = "science",
+            ReturnType = "object",
+            Params = "uint partId")]
+        object Dump(DataSources ds)
+        {
+            var exp = FindExperimentByPartId(ds.vessel, ds.args);
+            if (exp == null) return "instrument not found";
+
+            var data = exp.GetData();
+            if (data == null || data.Length == 0) return 0;
+
+            foreach (var d in data)
+            {
+                if (d != null) exp.DumpData(d);
+            }
+            return 0;
+        }
+
+        [TelemetryAPI("sci.reset",
+            "Reset experiment — clears Deployed + drops data, makes rerunnable instruments ready to run again",
+            IsAction = true,
+            Category = "science",
+            ReturnType = "object",
+            Params = "uint partId")]
+        object Reset(DataSources ds)
+        {
+            var exp = FindExperimentByPartId(ds.vessel, ds.args);
+            if (exp == null) return "instrument not found";
+            exp.ResetExperiment();
+            return 0;
+        }
+    }
+}

--- a/Telemachus/src/StrategiesDataLinkHandler.cs
+++ b/Telemachus/src/StrategiesDataLinkHandler.cs
@@ -1,0 +1,370 @@
+using System.Collections.Generic;
+using System.Reflection;
+using KSP.Localization;
+using Strategies;
+using UnityEngine;
+
+namespace Telemachus
+{
+    /// <summary>Career-mode Administration Building strategies. Read and
+    /// write actions; keys are global — vessel param ignored.</summary>
+    public class StrategiesDataLinkHandler : DataLinkHandler
+    {
+        public StrategiesDataLinkHandler(FormatterProvider formatters)
+            : base(formatters) { }
+
+        [TelemetryAPI("strategies.all",
+            "Every strategy (active + inactive). Per strategy: id, title, " +
+            "description, departmentName, isActive, factor, dateActivated, " +
+            "requiredReputation, initialCostFunds / initialCostScience / " +
+            "initialCostReputation (nominal, pre-curve), " +
+            "effectiveCostReputation (post-curve, the actual rep the " +
+            "player loses on activate), leastDuration, longestDuration, " +
+            "noDuration, hasFactorSlider, factorSliderDefault, " +
+            "factorSliderSteps, canActivate, activateBlockedReason, " +
+            "canDeactivate, deactivateBlockedReason, effect.",
+            AlwaysEvaluable = true,
+            Plotable = false,
+            Category = "career",
+            ReturnType = "object")]
+        object All(DataSources ds)
+        {
+            var result = new List<Dictionary<string, object>>();
+            var system = StrategySystem.Instance;
+            if (system == null || system.Strategies == null) return result;
+
+            foreach (var strat in system.Strategies)
+            {
+                if (strat == null || strat.Config == null) continue;
+
+                string activateReason;
+                bool canActivate = CanActivateReplica(strat, out activateReason);
+                string deactivateReason;
+                bool canDeactivate = CanDeactivateReplica(strat, out deactivateReason);
+
+                result.Add(new Dictionary<string, object>
+                {
+                    ["id"] = strat.Config.Name ?? string.Empty,
+                    ["title"] = strat.Title ?? string.Empty,
+                    ["description"] = strat.Description ?? string.Empty,
+                    ["departmentName"] = strat.DepartmentName ?? string.Empty,
+                    ["isActive"] = strat.IsActive,
+                    ["factor"] = strat.Factor,
+                    ["dateActivated"] = strat.DateActivated,
+                    ["requiredReputation"] = R4(strat.RequiredReputation),
+                    ["requiredReputationMin"] = R4(strat.RequiredReputationMin),
+                    ["requiredReputationMax"] = R4(strat.RequiredReputationMax),
+                    ["initialCostFunds"] = R4(strat.InitialCostFunds),
+                    ["initialCostFundsMin"] = R4(strat.InitialCostFundsMin),
+                    ["initialCostFundsMax"] = R4(strat.InitialCostFundsMax),
+                    ["initialCostScience"] = R4(strat.InitialCostScience),
+                    ["initialCostReputation"] = R4(strat.InitialCostReputation),
+                    ["effectiveCostReputation"] =
+                        EffectiveReputationCost(strat.InitialCostReputation),
+                    ["leastDuration"] = strat.LeastDuration,
+                    ["longestDuration"] = strat.LongestDuration,
+                    ["noDuration"] = strat.NoDuration,
+                    ["hasFactorSlider"] = strat.HasFactorSlider,
+                    ["factorSliderDefault"] = strat.FactorSliderDefault,
+                    ["factorSliderSteps"] = strat.FactorSliderSteps,
+                    ["canActivate"] = canActivate,
+                    ["activateBlockedReason"] = activateReason ?? string.Empty,
+                    ["canDeactivate"] = canDeactivate,
+                    ["deactivateBlockedReason"] = deactivateReason ?? string.Empty,
+                    ["effect"] = strat.Effect ?? string.Empty,
+                });
+            }
+            return result;
+        }
+
+        [TelemetryAPI("strategies.activate",
+            "Activate a strategy by id, setting its factor slider first. " +
+            "Returns 0 on success, or an error string (strategy not found, " +
+            "CanBeActivated reason, factor out of range, etc).",
+            AlwaysEvaluable = true,
+            IsAction = true,
+            Category = "career",
+            ReturnType = "object",
+            Params = "string strategyId, float factor")]
+        object Activate(DataSources ds)
+        {
+            if (ds.args == null || ds.args.Count < 1) return "missing strategy id";
+            var id = ds.args[0];
+            if (string.IsNullOrEmpty(id)) return "missing strategy id";
+
+            var system = StrategySystem.Instance;
+            if (system == null) return "no strategy system";
+
+            var strat = FindStrategy(system, id);
+            if (strat == null) return "strategy not found";
+
+            // Factor is optional — defaults to the slider's preset value.
+            // Pass NaN-as-string ("") or omit entirely to skip the set.
+            if (ds.args.Count >= 2 && !string.IsNullOrEmpty(ds.args[1]))
+            {
+                if (!float.TryParse(ds.args[1], out var factor))
+                    return "factor must be a float in [0, 1]";
+                if (factor < 0f || factor > 1f) return "factor out of [0, 1]";
+                strat.Factor = factor;
+            }
+
+            string reason;
+            if (!CanActivateReplica(strat, out reason))
+                return string.IsNullOrEmpty(reason) ? "cannot activate" : reason;
+
+            if (!ActivateReplica(strat))
+                return "activate failed";
+            return 0;
+        }
+
+        [TelemetryAPI("strategies.deactivate",
+            "Deactivate an active strategy by id. Returns 0 on success, or " +
+            "an error string (strategy not found, CanBeDeactivated reason).",
+            AlwaysEvaluable = true,
+            IsAction = true,
+            Category = "career",
+            ReturnType = "object",
+            Params = "string strategyId")]
+        object Deactivate(DataSources ds)
+        {
+            if (ds.args == null || ds.args.Count < 1) return "missing strategy id";
+            var id = ds.args[0];
+            if (string.IsNullOrEmpty(id)) return "missing strategy id";
+
+            var system = StrategySystem.Instance;
+            if (system == null) return "no strategy system";
+
+            var strat = FindStrategy(system, id);
+            if (strat == null) return "strategy not found";
+
+            string reason;
+            if (!CanDeactivateReplica(strat, out reason))
+                return string.IsNullOrEmpty(reason) ? "cannot deactivate" : reason;
+
+            if (!DeactivateReplica(strat))
+                return "deactivate failed";
+            return 0;
+        }
+
+        // ── KSP-replica section ──────────────────────────────────────
+        //
+        // KSP's Strategy.CanBeActivated / Activate / Deactivate dereference
+        // Administration.Instance, a MonoBehaviour live only while the
+        // Admin Building dialog is open. That makes the stock methods
+        // unusable from Telemachus when the player hasn't got the dialog
+        // up — and we don't want consumers to need to drive the KSP UI
+        // before calling our endpoints. The four methods below replicate
+        // each check / mutation against publicly-accessible state
+        // (StrategySystem, GameVariables, ScenarioUpgradeableFacilities,
+        // Funding, Reputation, ResearchAndDevelopment, Planetarium) so
+        // the same operations work in any scene. Behaviour matches stock
+        // KSP 1.12.
+        //
+        // Reflection is used only to write `isActive` and `dateActivated`,
+        // which stock KSP leaves private. Everything else is a public
+        // API call.
+
+        private static readonly FieldInfo IsActiveField =
+            typeof(Strategy).GetField("isActive",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+        private static readonly FieldInfo DateActivatedField =
+            typeof(Strategy).GetField("dateActivated",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+
+        private static int AdminLevel()
+        {
+            return ScenarioUpgradeableFacilities.GetFacilityLevel(
+                SpaceCenterFacility.Administration) > 0f ? 1 : 0;
+        }
+
+        private static int MaxActiveStrategies()
+        {
+            var gv = GameVariables.Instance;
+            if (gv == null) return 0;
+            return gv.GetActiveStrategyLimit(
+                ScenarioUpgradeableFacilities.GetFacilityLevel(
+                    SpaceCenterFacility.Administration));
+        }
+
+        private static float MaxCommitLevel()
+        {
+            var gv = GameVariables.Instance;
+            if (gv == null) return 0f;
+            return gv.GetStrategyCommitRange(
+                ScenarioUpgradeableFacilities.GetFacilityLevel(
+                    SpaceCenterFacility.Administration));
+        }
+
+        private static int ActiveStrategyCount(StrategySystem system)
+        {
+            int n = 0;
+            foreach (var s in system.Strategies)
+                if (s != null && s.IsActive) n++;
+            return n;
+        }
+
+        // Mirrors Strategy.CanBeActivated. Same order and same messages.
+        private static bool CanActivateReplica(Strategy s, out string reason)
+        {
+            reason = string.Empty;
+            var system = StrategySystem.Instance;
+            if (system == null) { reason = "no strategy system"; return false; }
+
+            if (ActiveStrategyCount(system) >= MaxActiveStrategies())
+            {
+                reason = Localizer.Format("#autoLOC_304820", MaxActiveStrategies());
+                return false;
+            }
+            if (system.HasConflictingActiveStrategies(s.GroupTags))
+            {
+                reason = Localizer.Format("#autoLOC_304827");
+                return false;
+            }
+            if (s.Factor > MaxCommitLevel())
+            {
+                reason = Localizer.Format("#autoLOC_304834",
+                    MaxCommitLevel() * 100f);
+                return false;
+            }
+            if (s.InitialCostFunds != 0f
+                && Funding.Instance != null
+                && Funding.Instance.Funds < s.InitialCostFunds)
+            {
+                reason = Localizer.Format("#autoLOC_304845",
+                    s.InitialCostFunds.ToString("N0"));
+                return false;
+            }
+            if (s.InitialCostReputation != 0f
+                && Reputation.Instance != null
+                && Reputation.Instance.reputation < s.InitialCostReputation)
+            {
+                reason = Localizer.Format("#autoLOC_304854",
+                    s.InitialCostReputation.ToString("N0"));
+                return false;
+            }
+            if (s.InitialCostScience != 0f
+                && !ResearchAndDevelopment.CanAfford(s.InitialCostScience))
+            {
+                reason = Localizer.Format("#autoLOC_304862",
+                    s.InitialCostScience.ToString("N0"));
+                return false;
+            }
+            if (s.RequiredReputation != 0f
+                && Mathf.Ceil(Reputation.CurrentRep)
+                   < Mathf.Floor(s.RequiredReputation))
+            {
+                reason = Localizer.Format("#autoLOC_304862",
+                    s.RequiredReputation.ToString("N0"),
+                    Reputation.CurrentRep.ToString("N0"));
+                return false;
+            }
+            return true;
+        }
+
+        // Mirrors Strategy.CanBeDeactivated — much simpler.
+        private static bool CanDeactivateReplica(Strategy s, out string reason)
+        {
+            reason = string.Empty;
+            if (!s.IsActive) { reason = "Strategy is not active"; return false; }
+            return true;
+        }
+
+        // Mirrors Strategy.Activate. Reflection writes the two private
+        // fields; everything else is a public API call.
+        private static bool ActivateReplica(Strategy s)
+        {
+            if (IsActiveField == null || DateActivatedField == null)
+                return false;
+            IsActiveField.SetValue(s, true);
+            s.Register();
+            DateActivatedField.SetValue(s, Planetarium.fetch.time);
+            if (s.InitialCostFunds != 0f && Funding.Instance != null)
+                Funding.Instance.AddFunds(
+                    0f - Mathf.Abs(s.InitialCostFunds),
+                    TransactionReasons.StrategySetup);
+            if (s.InitialCostReputation != 0f && Reputation.Instance != null)
+                Reputation.Instance.AddReputation(
+                    0f - Mathf.Abs(s.InitialCostReputation),
+                    TransactionReasons.StrategySetup);
+            if (s.InitialCostScience != 0f
+                && ResearchAndDevelopment.Instance != null)
+                ResearchAndDevelopment.Instance.AddScience(
+                    0f - Mathf.Abs(s.InitialCostScience),
+                    TransactionReasons.StrategySetup);
+            return true;
+        }
+
+        // Mirrors Strategy.Deactivate.
+        private static bool DeactivateReplica(Strategy s)
+        {
+            if (IsActiveField == null) return false;
+            IsActiveField.SetValue(s, false);
+            s.Unregister();
+            return true;
+        }
+
+        // ── end KSP-replica section ──────────────────────────────────
+
+        private static Strategy FindStrategy(StrategySystem system, string id)
+        {
+            foreach (var s in system.Strategies)
+            {
+                if (s == null || s.Config == null) continue;
+                if (s.Config.Name == id) return s;
+            }
+            return null;
+        }
+
+        // Compute the reputation cost the player will *actually* lose on
+        // activate, after KSP's nonlinear reputation curve. KSP runs
+        // Strategy.Activate's `Reputation.AddReputation(-nominalCost, …)`
+        // through `Reputation.addReputation_granular`, which multiplies
+        // each unit step by `GameVariables.Instance.reputationSubtraction
+        // .Evaluate(rep / RepRange)`. The curve makes losing rep near the
+        // cap cost significantly more than at zero — e.g. a nominal 14.5
+        // cost can deduct ~27 when the player is at 976 rep. Reproduce the
+        // per-unit walk here so the widget shows the actual cost, not the
+        // misleading nominal.
+        private static double EffectiveReputationCost(float nominalCost)
+        {
+            if (nominalCost == 0f) return 0d;
+            var rep = Reputation.Instance;
+            var gv = GameVariables.Instance;
+            // No career / no game-variables → no curve to apply. Return
+            // the nominal value so the field is at least meaningful.
+            if (rep == null || gv == null || gv.reputationSubtraction == null)
+                return System.Math.Round(nominalCost, 4);
+
+            float current = rep.reputation;
+            float remaining = System.Math.Abs(nominalCost);
+            double totalLoss = 0d;
+            // Same walk Reputation.addReputation_granular uses: subtract
+            // one unit at a time, applying the curve at each step's
+            // current rep position, accumulating the real total.
+            int steps = (int)remaining;
+            for (int i = 0; i < steps; i++)
+            {
+                float time = current / Reputation.RepRange;
+                float mult = gv.reputationSubtraction.Evaluate(time);
+                float delta = mult; // walking a unit-magnitude step
+                totalLoss += delta;
+                current -= delta;
+                remaining -= 1f;
+            }
+            // Fractional remainder picks up the final partial step.
+            if (remaining > 0f)
+            {
+                float time = current / Reputation.RepRange;
+                float mult = gv.reputationSubtraction.Evaluate(time);
+                totalLoss += remaining * mult;
+            }
+            return System.Math.Round(totalLoss, 4);
+        }
+
+        // Round-to-4 helper, matching the convention used by
+        // KscDataLinkHandler / TechTreeDataLinkHandler for currency-style
+        // floats. Doubles pass through unchanged — the formatter handles
+        // them.
+        private static double R4(float v) => System.Math.Round(v, 4);
+    }
+}

--- a/Telemachus/src/TechTreeDataLinkHandler.cs
+++ b/Telemachus/src/TechTreeDataLinkHandler.cs
@@ -172,7 +172,7 @@ namespace Telemachus
         }
 
         [TelemetryAPI("tech.nodes",
-            "Full tech tree — every node with id, title, description, scienceCost, state, parents, parts",
+            "Full tech tree — every node with id, title, description, scienceCost, scienceCostEffective (post strategy modifier), state, parents, parts[name,title,manufacturer,category,entryCost,entryCostEffective,purchased]",
             AlwaysEvaluable = true,
             Plotable = false,
             Category = "career",
@@ -226,25 +226,35 @@ namespace Telemachus
                     foreach (var p in partsList)
                     {
                         if (p == null) continue;
+                        var entryCost = p.entryCost;
+                        var entryCostEffective = entryCost > 0
+                            ? CurrencyModifiers.Funds(entryCost, TransactionReasons.RnDPartPurchase)
+                            : 0f;
                         parts.Add(new Dictionary<string, object>
                         {
                             ["name"] = p.name,
                             ["title"] = p.title ?? p.name,
                             ["manufacturer"] = p.manufacturer ?? string.Empty,
                             ["category"] = p.category.ToString(),
-                            ["entryCost"] = p.entryCost,
+                            ["entryCost"] = entryCost,
+                            ["entryCostEffective"] = entryCostEffective,
                             ["purchased"] = ResearchAndDevelopment.PartTechAvailable(p)
                                 && ResearchAndDevelopment.PartModelPurchased(p),
                         });
                     }
                 }
 
+                var nominalSci = (float)node.tech.scienceCost;
+                var effectiveSci = nominalSci > 0f
+                    ? CurrencyModifiers.Science(nominalSci, TransactionReasons.RnDTechResearch)
+                    : 0f;
                 result.Add(new Dictionary<string, object>
                 {
                     ["id"] = techID,
                     ["title"] = title,
                     ["description"] = description ?? string.Empty,
                     ["scienceCost"] = node.tech.scienceCost,
+                    ["scienceCostEffective"] = effectiveSci,
                     ["state"] = ResearchAndDevelopment.GetTechnologyState(techID).ToString(),
                     ["parents"] = parents,
                     ["parts"] = parts,

--- a/Telemachus/src/TechTreeDataLinkHandler.cs
+++ b/Telemachus/src/TechTreeDataLinkHandler.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using KSP.Localization;
+using KSP.UI.Screens;
 
 namespace Telemachus
 {
@@ -9,6 +11,10 @@ namespace Telemachus
         // Sticky-cache covers the one-frame mid-load window where every node briefly reports Unavailable.
         private static List<string> _cachedUnlockedIds;
         private static List<Dictionary<string, object>> _cachedAffordable;
+        // Built once per game-load: parsed from the TechTree.cfg ConfigNode
+        // and PartLoader respectively. Both are invariant within a session.
+        private static Dictionary<string, string> _descriptionsByTech;
+        private static Dictionary<string, List<AvailablePart>> _partsByTech;
 
         public TechTreeDataLinkHandler(FormatterProvider formatters)
             : base(formatters) { }
@@ -101,6 +107,150 @@ namespace Telemachus
                 });
             }
             _cachedAffordable = result;
+            return result;
+        }
+
+        // Sticky-cache covers the same mid-load window as unlockedIds /
+        // affordable: every node briefly reports Unavailable while RnD
+        // rehydrates, which would clobber the prerequisite graph for any
+        // subscriber that polls during that window.
+        private static List<Dictionary<string, object>> _cachedNodes;
+
+        // Build session-stable indexes for description (parsed from the
+        // tree's underlying ConfigNode) and parts-per-tech (from PartLoader).
+        // ResearchAndDevelopment.GetTechnologyTitle covers titles already;
+        // there's no equivalent helper for descriptions, hence the cfg parse.
+        // PartLoader's LoadedPartsList stamps AvailablePart.TechRequired
+        // on every loaded part, so the inverse index is a single pass.
+        private static void EnsureIndexes(RDTechTree tree)
+        {
+            if (_descriptionsByTech == null)
+            {
+                var dict = new Dictionary<string, string>();
+                var cfg = tree.GetTreeConfigNode();
+                if (cfg != null)
+                {
+                    foreach (var sub in cfg.GetNodes("RDNode"))
+                    {
+                        if (sub == null) continue;
+                        var id = sub.GetValue("id");
+                        if (string.IsNullOrEmpty(id)) continue;
+                        var raw = sub.GetValue("description");
+                        if (string.IsNullOrEmpty(raw))
+                        {
+                            dict[id] = string.Empty;
+                            continue;
+                        }
+                        // Resolve #autoLOC_xxx tokens. Localizer.Format passes
+                        // plain strings through unchanged, so this is safe for
+                        // non-localized custom trees too.
+                        dict[id] = Localizer.Format(raw);
+                    }
+                }
+                _descriptionsByTech = dict;
+            }
+
+            if (_partsByTech == null)
+            {
+                var byTech = new Dictionary<string, List<AvailablePart>>();
+                var list = PartLoader.LoadedPartsList;
+                if (list != null)
+                {
+                    foreach (var p in list)
+                    {
+                        if (p == null || string.IsNullOrEmpty(p.TechRequired)) continue;
+                        if (!byTech.TryGetValue(p.TechRequired, out var bucket))
+                        {
+                            bucket = new List<AvailablePart>();
+                            byTech[p.TechRequired] = bucket;
+                        }
+                        bucket.Add(p);
+                    }
+                }
+                _partsByTech = byTech;
+            }
+        }
+
+        [TelemetryAPI("tech.nodes",
+            "Full tech tree — every node with id, title, description, scienceCost, state, parents, parts",
+            AlwaysEvaluable = true,
+            Plotable = false,
+            Category = "career",
+            ReturnType = "object")]
+        object Nodes(DataSources ds)
+        {
+            if (ResearchAndDevelopment.Instance == null) return new List<Dictionary<string, object>>();
+
+            var tree = AssetBase.RnDTechTree;
+            if (tree == null) return new List<Dictionary<string, object>>();
+
+            if (IsTransientLoadingState() && _cachedNodes != null)
+                return new List<Dictionary<string, object>>(_cachedNodes);
+
+            EnsureIndexes(tree);
+
+            // GetTreeNodes() returns ProtoRDNode[] — runtime tree snapshot.
+            // Each ProtoRDNode has `tech` (ProtoTechNode) and `parents`
+            // (List<ProtoRDNode> — elements ARE the parent nodes, no
+            // wrapper). Title comes from ResearchAndDevelopment, description
+            // from the cfg-parsed index, parts from the PartLoader index.
+            var nodes = tree.GetTreeNodes();
+            if (nodes == null) return new List<Dictionary<string, object>>();
+
+            var result = new List<Dictionary<string, object>>();
+            foreach (var node in nodes)
+            {
+                if (node == null || node.tech == null) continue;
+                var techID = node.tech.techID;
+                if (string.IsNullOrEmpty(techID)) continue;
+
+                var parents = new List<string>();
+                if (node.parents != null)
+                {
+                    foreach (var p in node.parents)
+                    {
+                        if (p == null || p.tech == null) continue;
+                        var pid = p.tech.techID;
+                        if (!string.IsNullOrEmpty(pid)) parents.Add(pid);
+                    }
+                }
+
+                var title = ResearchAndDevelopment.GetTechnologyTitle(techID);
+                if (string.IsNullOrEmpty(title)) title = techID;
+                _descriptionsByTech.TryGetValue(techID, out var description);
+                _partsByTech.TryGetValue(techID, out var partsList);
+
+                var parts = new List<Dictionary<string, object>>();
+                if (partsList != null)
+                {
+                    foreach (var p in partsList)
+                    {
+                        if (p == null) continue;
+                        parts.Add(new Dictionary<string, object>
+                        {
+                            ["name"] = p.name,
+                            ["title"] = p.title ?? p.name,
+                            ["manufacturer"] = p.manufacturer ?? string.Empty,
+                            ["category"] = p.category.ToString(),
+                            ["entryCost"] = p.entryCost,
+                            ["purchased"] = ResearchAndDevelopment.PartTechAvailable(p)
+                                && ResearchAndDevelopment.PartModelPurchased(p),
+                        });
+                    }
+                }
+
+                result.Add(new Dictionary<string, object>
+                {
+                    ["id"] = techID,
+                    ["title"] = title,
+                    ["description"] = description ?? string.Empty,
+                    ["scienceCost"] = node.tech.scienceCost,
+                    ["state"] = ResearchAndDevelopment.GetTechnologyState(techID).ToString(),
+                    ["parents"] = parents,
+                    ["parts"] = parts,
+                });
+            }
+            _cachedNodes = result;
             return result;
         }
 

--- a/Telemachus/src/TechTreeDataLinkHandler.cs
+++ b/Telemachus/src/TechTreeDataLinkHandler.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+
+namespace Telemachus
+{
+    /// <summary>Tech-tree state. Keys are global — vessel param ignored.</summary>
+    public class TechTreeDataLinkHandler : DataLinkHandler
+    {
+        // Sticky-cache covers the one-frame mid-load window where every node briefly reports Unavailable.
+        private static List<string> _cachedUnlockedIds;
+        private static List<Dictionary<string, object>> _cachedAffordable;
+
+        public TechTreeDataLinkHandler(FormatterProvider formatters)
+            : base(formatters) { }
+
+        // Tree owner is AssetBase.RnDTechTree; per-player state via GetTechnologyState(id), not ProtoTechNode.state.
+        private static ProtoTechNode[] GetTreeTechs()
+        {
+            var tree = AssetBase.RnDTechTree;
+            if (tree == null) return Array.Empty<ProtoTechNode>();
+            return tree.GetTreeTechs() ?? Array.Empty<ProtoTechNode>();
+        }
+
+        // `start` always unlocked in any career save — if reported Unavailable, we're mid-load.
+        private static bool IsTransientLoadingState()
+        {
+            if (ResearchAndDevelopment.Instance == null) return false;
+            return ResearchAndDevelopment.GetTechnologyState("start")
+                != RDTech.State.Available;
+        }
+
+        [TelemetryAPI("tech.unlockedIds",
+            "Tech-tree node ids the player has researched",
+            AlwaysEvaluable = true,
+            Plotable = false,
+            Category = "career",
+            ReturnType = "object")]
+        object UnlockedIds(DataSources ds)
+        {
+            if (ResearchAndDevelopment.Instance == null) return new List<string>();
+
+            if (IsTransientLoadingState() && _cachedUnlockedIds != null)
+                return new List<string>(_cachedUnlockedIds);
+
+            var result = new List<string>();
+            foreach (var node in GetTreeTechs())
+            {
+                if (node == null) continue;
+                if (ResearchAndDevelopment.GetTechnologyState(node.techID)
+                    == RDTech.State.Available)
+                {
+                    result.Add(node.techID);
+                }
+            }
+            _cachedUnlockedIds = result;
+            return result;
+        }
+
+        [TelemetryAPI("tech.unlockedPartCount",
+            "Number of parts purchasable under current tech",
+            AlwaysEvaluable = true,
+            Category = "career",
+            ReturnType = "int")]
+        object UnlockedPartCount(DataSources ds)
+        {
+            if (PartLoader.LoadedPartsList == null) return 0;
+            var count = 0;
+            foreach (var part in PartLoader.LoadedPartsList)
+            {
+                if (ResearchAndDevelopment.PartTechAvailable(part)) count++;
+            }
+            return count;
+        }
+
+        [TelemetryAPI("tech.affordable",
+            "Tech-tree nodes affordable right now (not yet unlocked, scienceCost <= current science)",
+            AlwaysEvaluable = true,
+            Plotable = false,
+            Category = "career",
+            ReturnType = "object")]
+        object Affordable(DataSources ds)
+        {
+            var rd = ResearchAndDevelopment.Instance;
+            if (rd == null) return new List<Dictionary<string, object>>();
+
+            if (IsTransientLoadingState() && _cachedAffordable != null)
+                return new List<Dictionary<string, object>>(_cachedAffordable);
+
+            var result = new List<Dictionary<string, object>>();
+            var available = rd.Science;
+            foreach (var node in GetTreeTechs())
+            {
+                if (node == null) continue;
+                if (ResearchAndDevelopment.GetTechnologyState(node.techID)
+                    == RDTech.State.Available) continue;
+                if (node.scienceCost > available) continue;
+                result.Add(new Dictionary<string, object>
+                {
+                    ["id"] = node.techID,
+                    ["scienceCost"] = node.scienceCost,
+                });
+            }
+            _cachedAffordable = result;
+            return result;
+        }
+
+        [TelemetryAPI("tech.unlock",
+            "Unlock a tech-tree node — deducts science, marks node Available",
+            AlwaysEvaluable = true,
+            IsAction = true,
+            Category = "career",
+            ReturnType = "object",
+            Params = "string techId")]
+        object Unlock(DataSources ds)
+        {
+            if (ds.args == null || ds.args.Count == 0) return "missing tech id";
+            var techId = ds.args[0];
+            if (string.IsNullOrEmpty(techId)) return "missing tech id";
+
+            var rd = ResearchAndDevelopment.Instance;
+            if (rd == null) return "no R&D scenario";
+
+            ProtoTechNode target = null;
+            foreach (var node in GetTreeTechs())
+            {
+                if (node != null && node.techID == techId)
+                {
+                    target = node;
+                    break;
+                }
+            }
+            if (target == null) return "tech not found";
+            if (ResearchAndDevelopment.GetTechnologyState(target.techID)
+                == RDTech.State.Available) return 0; // idempotent
+            if (target.scienceCost > rd.Science) return "insufficient science";
+
+            // UnlockProtoTechNode is Unity-coupled — relies on IsAction auto-defer to run on main thread.
+            ResearchAndDevelopment.Instance.AddScience(
+                -target.scienceCost,
+                TransactionReasons.RnDTechResearch);
+            ResearchAndDevelopment.Instance.UnlockProtoTechNode(target);
+            return 0;
+        }
+    }
+}

--- a/docs/api-schema.json
+++ b/docs/api-schema.json
@@ -1935,7 +1935,7 @@
   },
   {
     "key": "kc.facilityLevels",
-    "description": "Per-facility { level, max, upgradeFunds, currentLevelText, nextLevelText } for the 9 stock SC buildings",
+    "description": "Per-facility { level, max, upgradeFunds, upgradeFundsEffective (post strategy modifier), currentLevelText, nextLevelText } for the 9 stock SC buildings",
     "units": "UNITLESS",
     "plotable": false,
     "isAction": false,
@@ -1990,7 +1990,7 @@
   },
   {
     "key": "kc.savedShips",
-    "description": "Saved craft files in VAB+SPH — name, partCount, totalMass, facility, requiresFunds, missingParts",
+    "description": "Saved craft files in VAB+SPH — name, partCount, totalMass, facility, requiresFunds, requiresFundsEffective (post strategy modifier), missingParts",
     "units": "UNITLESS",
     "plotable": false,
     "isAction": false,
@@ -4935,7 +4935,7 @@
   },
   {
     "key": "tech.nodes",
-    "description": "Full tech tree — every node with id, title, description, scienceCost, state, parents, parts",
+    "description": "Full tech tree — every node with id, title, description, scienceCost (+ scienceCostEffective post modifier), state, parents, parts (each part includes entryCost + entryCostEffective)",
     "units": "UNITLESS",
     "plotable": false,
     "isAction": false,
@@ -4977,6 +4977,41 @@
     "category": "career",
     "returnType": "int",
     "declaringClass": "TechTreeDataLinkHandler"
+  },
+  {
+    "key": "strategies.all",
+    "description": "Every career strategy with full read fields plus canActivate / canDeactivate gates that work in any scene.",
+    "units": "UNITLESS",
+    "plotable": false,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "career",
+    "returnType": "object",
+    "declaringClass": "StrategiesDataLinkHandler"
+  },
+  {
+    "key": "strategies.activate",
+    "description": "Activate a strategy by id at a given factor. Works in any scene; KSP's CanBeActivated logic is replicated against public state.",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": true,
+    "alwaysEvaluable": true,
+    "category": "career",
+    "returnType": "object",
+    "params": "string strategyId, float factor",
+    "declaringClass": "StrategiesDataLinkHandler"
+  },
+  {
+    "key": "strategies.deactivate",
+    "description": "Deactivate an active strategy by id. Works in any scene.",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": true,
+    "alwaysEvaluable": true,
+    "category": "career",
+    "returnType": "object",
+    "params": "string strategyId",
+    "declaringClass": "StrategiesDataLinkHandler"
   },
   {
     "key": "therm.anyEnginesOverheating",

--- a/docs/api-schema.json
+++ b/docs/api-schema.json
@@ -1935,7 +1935,7 @@
   },
   {
     "key": "kc.facilityLevels",
-    "description": "Per-facility { level, max, upgradeFunds } for the 9 stock SC buildings",
+    "description": "Per-facility { level, max, upgradeFunds, currentLevelText, nextLevelText } for the 9 stock SC buildings",
     "units": "UNITLESS",
     "plotable": false,
     "isAction": false,
@@ -4925,6 +4925,17 @@
   {
     "key": "tech.affordable",
     "description": "Tech-tree nodes affordable right now (not yet unlocked, scienceCost <= current science)",
+    "units": "UNITLESS",
+    "plotable": false,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "career",
+    "returnType": "object",
+    "declaringClass": "TechTreeDataLinkHandler"
+  },
+  {
+    "key": "tech.nodes",
+    "description": "Full tech tree — every node with id, title, description, scienceCost, state, parents, parts",
     "units": "UNITLESS",
     "plotable": false,
     "isAction": false,

--- a/docs/api-schema.json
+++ b/docs/api-schema.json
@@ -39,8 +39,7 @@
     "alwaysEvaluable": true,
     "category": "system",
     "returnType": "object",
-    "declaringClass": "APIDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/SystemHandlers.cs"
+    "declaringClass": "APIDataLinkHandler"
   },
   {
     "key": "a.physicsMode",
@@ -51,8 +50,7 @@
     "alwaysEvaluable": true,
     "category": "system",
     "returnType": "string",
-    "declaringClass": "APIDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/SystemHandlers.cs"
+    "declaringClass": "APIDataLinkHandler"
   },
   {
     "key": "a.schema",
@@ -63,8 +61,7 @@
     "alwaysEvaluable": true,
     "category": "system",
     "returnType": "object",
-    "declaringClass": "APIDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/SystemHandlers.cs"
+    "declaringClass": "APIDataLinkHandler"
   },
   {
     "key": "a.version",
@@ -75,8 +72,7 @@
     "alwaysEvaluable": true,
     "category": "system",
     "returnType": "string",
-    "declaringClass": "APIDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/SystemHandlers.cs"
+    "declaringClass": "APIDataLinkHandler"
   },
   {
     "key": "alarm.count",
@@ -87,8 +83,7 @@
     "alwaysEvaluable": false,
     "category": "alarm",
     "returnType": "int",
-    "declaringClass": "AlarmClockDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AlarmClockHandlers.cs"
+    "declaringClass": "AlarmClockDataLinkHandler"
   },
   {
     "key": "alarm.list",
@@ -100,8 +95,7 @@
     "category": "alarm",
     "returnType": "object",
     "formatter": "AlarmList",
-    "declaringClass": "AlarmClockDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AlarmClockHandlers.cs"
+    "declaringClass": "AlarmClockDataLinkHandler"
   },
   {
     "key": "alarm.nextAlarm",
@@ -113,8 +107,7 @@
     "category": "alarm",
     "returnType": "object",
     "formatter": "Alarm",
-    "declaringClass": "AlarmClockDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AlarmClockHandlers.cs"
+    "declaringClass": "AlarmClockDataLinkHandler"
   },
   {
     "key": "alarm.timeToNext",
@@ -125,8 +118,7 @@
     "alwaysEvaluable": false,
     "category": "alarm",
     "returnType": "double",
-    "declaringClass": "AlarmClockDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AlarmClockHandlers.cs"
+    "declaringClass": "AlarmClockDataLinkHandler"
   },
   {
     "key": "astg.active",
@@ -135,8 +127,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.activeTransfer",
@@ -145,8 +136,7 @@
     "plotable": false,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.available",
@@ -155,8 +145,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": true,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.createManeuver",
@@ -165,8 +154,7 @@
     "plotable": true,
     "isAction": true,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.errorCondition",
@@ -175,8 +163,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.hyperbolicOrbit",
@@ -185,8 +172,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.nextBurnCountdown",
@@ -195,8 +181,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.nextBurnTime",
@@ -205,8 +190,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.nextDeltaV",
@@ -215,8 +199,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.nextDestination",
@@ -225,8 +208,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.retrogradeOrbit",
@@ -235,8 +217,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.transfer",
@@ -245,8 +226,7 @@
     "plotable": false,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.transferCount",
@@ -255,8 +235,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.transfers",
@@ -265,8 +244,7 @@
     "plotable": false,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.warpToBurn",
@@ -275,8 +253,7 @@
     "plotable": true,
     "isAction": true,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "b.angularV",
@@ -288,8 +265,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.atmosphere",
@@ -301,8 +277,7 @@
     "category": "body",
     "returnType": "bool",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.atmosphereContainsOxygen",
@@ -314,8 +289,7 @@
     "category": "body",
     "returnType": "bool",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.description",
@@ -327,8 +301,7 @@
     "category": "body",
     "returnType": "string",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.geeASL",
@@ -340,8 +313,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.hillSphere",
@@ -353,8 +325,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.index",
@@ -366,8 +337,7 @@
     "category": "body",
     "returnType": "int",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.mass",
@@ -379,8 +349,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.maxAtmosphere",
@@ -392,8 +361,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.name",
@@ -405,8 +373,7 @@
     "category": "body",
     "returnType": "string",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.number",
@@ -417,8 +384,7 @@
     "alwaysEvaluable": false,
     "category": "body",
     "returnType": "int",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.ApA",
@@ -430,8 +396,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.argumentOfPeriapsis",
@@ -443,8 +408,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.eccentricity",
@@ -456,8 +420,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.gravParameter",
@@ -469,8 +432,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.inclination",
@@ -482,8 +444,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.lan",
@@ -495,8 +456,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.maae",
@@ -508,8 +468,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.PeA",
@@ -521,8 +480,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.period",
@@ -534,8 +492,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.phaseAngle",
@@ -547,8 +504,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.relativeVelocity",
@@ -560,8 +516,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.sma",
@@ -573,8 +528,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.timeOfPeriapsisPassage",
@@ -586,8 +540,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.timeToAp",
@@ -599,8 +552,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.timeToPe",
@@ -612,8 +564,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.timeToTransition1",
@@ -625,8 +576,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.timeToTransition2",
@@ -638,8 +588,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.trueAnomaly",
@@ -651,8 +600,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.truePositionAtUT",
@@ -665,8 +613,7 @@
     "returnType": "Vector3d",
     "params": "int bodyId, double UT",
     "formatter": "Vector3d",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.ocean",
@@ -678,8 +625,7 @@
     "category": "body",
     "returnType": "bool",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.orbitingBodies",
@@ -692,8 +638,7 @@
     "returnType": "string[]",
     "params": "int bodyId",
     "formatter": "StringArray",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.position",
@@ -706,8 +651,7 @@
     "returnType": "Vector3d",
     "params": "int bodyId",
     "formatter": "Vector3d",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.radius",
@@ -719,8 +663,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.referenceBody",
@@ -732,8 +675,7 @@
     "category": "body",
     "returnType": "string",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.rotates",
@@ -745,8 +687,7 @@
     "category": "body",
     "returnType": "bool",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.rotationAngle",
@@ -758,8 +699,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.rotationPeriod",
@@ -771,8 +711,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.soi",
@@ -784,8 +723,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.tidallyLocked",
@@ -797,8 +735,7 @@
     "category": "body",
     "returnType": "bool",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.timeWarpAltitudeLimits",
@@ -810,8 +747,7 @@
     "category": "body",
     "returnType": "object",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "career.funds",
@@ -822,8 +758,7 @@
     "alwaysEvaluable": true,
     "category": "career",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "career.mode",
@@ -834,8 +769,7 @@
     "alwaysEvaluable": true,
     "category": "career",
     "returnType": "string",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "career.reputation",
@@ -846,8 +780,7 @@
     "alwaysEvaluable": true,
     "category": "career",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "career.science",
@@ -858,8 +791,7 @@
     "alwaysEvaluable": true,
     "category": "career",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "comm.connected",
@@ -870,8 +802,7 @@
     "alwaysEvaluable": false,
     "category": "comms",
     "returnType": "bool",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "comm.controlState",
@@ -882,8 +813,7 @@
     "alwaysEvaluable": false,
     "category": "comms",
     "returnType": "int",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "comm.controlStateName",
@@ -894,8 +824,7 @@
     "alwaysEvaluable": false,
     "category": "comms",
     "returnType": "string",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "comm.signalDelay",
@@ -906,8 +835,7 @@
     "alwaysEvaluable": false,
     "category": "comms",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "comm.signalStrength",
@@ -918,8 +846,76 @@
     "alwaysEvaluable": false,
     "category": "comms",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
+  },
+  {
+    "key": "contracts.accept",
+    "description": "Accept an Offered contract (moves to Active)",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": true,
+    "alwaysEvaluable": true,
+    "category": "career",
+    "returnType": "object",
+    "params": "long contractId",
+    "declaringClass": "ContractsDataLinkHandler"
+  },
+  {
+    "key": "contracts.active",
+    "description": "All Active contracts with parameters + reward shape",
+    "units": "UNITLESS",
+    "plotable": false,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "career",
+    "returnType": "object",
+    "declaringClass": "ContractsDataLinkHandler"
+  },
+  {
+    "key": "contracts.cancel",
+    "description": "Cancel an Active contract — forfeits work in progress; only valid for Active",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": true,
+    "alwaysEvaluable": true,
+    "category": "career",
+    "returnType": "object",
+    "params": "long contractId",
+    "declaringClass": "ContractsDataLinkHandler"
+  },
+  {
+    "key": "contracts.completedRecent",
+    "description": "Last N completed-or-failed contracts, newest-first",
+    "units": "UNITLESS",
+    "plotable": false,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "career",
+    "returnType": "object",
+    "declaringClass": "ContractsDataLinkHandler"
+  },
+  {
+    "key": "contracts.decline",
+    "description": "Decline an Offered contract — different verb from cancel; only valid for Offered",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": true,
+    "alwaysEvaluable": true,
+    "category": "career",
+    "returnType": "object",
+    "params": "long contractId",
+    "declaringClass": "ContractsDataLinkHandler"
+  },
+  {
+    "key": "contracts.offered",
+    "description": "Contracts in Mission Control awaiting accept",
+    "units": "UNITLESS",
+    "plotable": false,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "career",
+    "returnType": "object",
+    "declaringClass": "ContractsDataLinkHandler"
   },
   {
     "key": "dock.ax",
@@ -930,8 +926,7 @@
     "alwaysEvaluable": false,
     "category": "docking",
     "returnType": "double",
-    "declaringClass": "DockingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "DockingDataLinkHandler"
   },
   {
     "key": "dock.ay",
@@ -942,8 +937,7 @@
     "alwaysEvaluable": false,
     "category": "docking",
     "returnType": "double",
-    "declaringClass": "DockingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "DockingDataLinkHandler"
   },
   {
     "key": "dock.az",
@@ -954,8 +948,7 @@
     "alwaysEvaluable": false,
     "category": "docking",
     "returnType": "double",
-    "declaringClass": "DockingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "DockingDataLinkHandler"
   },
   {
     "key": "dock.x",
@@ -966,8 +959,7 @@
     "alwaysEvaluable": false,
     "category": "docking",
     "returnType": "double",
-    "declaringClass": "DockingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "DockingDataLinkHandler"
   },
   {
     "key": "dock.y",
@@ -978,8 +970,7 @@
     "alwaysEvaluable": false,
     "category": "docking",
     "returnType": "double",
-    "declaringClass": "DockingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "DockingDataLinkHandler"
   },
   {
     "key": "dv.ready",
@@ -990,8 +981,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "double",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stage",
@@ -1004,8 +994,7 @@
     "returnType": "object",
     "params": "int stage",
     "formatter": "DeltaVStageInfo",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageBurnTime",
@@ -1017,8 +1006,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageCount",
@@ -1029,8 +1017,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "int",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageDryMass",
@@ -1042,8 +1029,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageDVActual",
@@ -1055,8 +1041,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageDVASL",
@@ -1068,8 +1053,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageDVVac",
@@ -1081,8 +1065,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageEndMass",
@@ -1094,8 +1077,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageFuelMass",
@@ -1107,8 +1089,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageISPActual",
@@ -1120,8 +1101,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageISPASL",
@@ -1133,8 +1113,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageISPVac",
@@ -1146,8 +1125,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageMass",
@@ -1159,8 +1137,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stages",
@@ -1172,8 +1149,7 @@
     "category": "deltav",
     "returnType": "object",
     "formatter": "DeltaVStageInfoList",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageStartMass",
@@ -1185,8 +1161,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageThrustActual",
@@ -1198,8 +1173,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageThrustASL",
@@ -1211,8 +1185,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageThrustVac",
@@ -1224,8 +1197,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageTWRActual",
@@ -1237,8 +1209,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageTWRASL",
@@ -1250,8 +1221,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageTWRVac",
@@ -1263,8 +1233,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.totalBurnTime",
@@ -1275,8 +1244,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "double",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.totalDVActual",
@@ -1287,8 +1255,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "double",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.totalDVASL",
@@ -1299,8 +1266,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "double",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.totalDVVac",
@@ -1311,8 +1277,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "double",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "f.abort",
@@ -1323,6 +1288,17 @@
     "category": "flight",
     "returnType": "int",
     "params": "bool? onOff"
+  },
+  {
+    "key": "f.ag.bindings",
+    "description": "Per-action flat list of action-group bindings on the active vessel: { actionGroup, partId, partName, partTitle, moduleName, actionName, actionGuiName }. One row per (action, group) pair — an action bound to two groups emits two rows. Actions with no group (None) are omitted.",
+    "units": "UNITLESS",
+    "plotable": false,
+    "isAction": false,
+    "alwaysEvaluable": false,
+    "category": "control",
+    "returnType": "object",
+    "declaringClass": "ActionGroupBindingsDataLinkHandler"
   },
   {
     "key": "f.ag1",
@@ -1453,8 +1429,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.killRot",
@@ -1465,8 +1440,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.light",
@@ -1487,8 +1461,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.pitchTrim",
@@ -1499,8 +1472,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.precisionControl",
@@ -1531,8 +1503,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.rollTrim",
@@ -1543,8 +1514,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.sas",
@@ -1565,8 +1535,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.sasMode",
@@ -1577,8 +1546,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "string",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.setPitchTrim",
@@ -1590,8 +1558,7 @@
     "category": "flight",
     "returnType": "int",
     "params": "float trim",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.setRollTrim",
@@ -1603,8 +1570,7 @@
     "category": "flight",
     "returnType": "int",
     "params": "float trim",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.setSASMode",
@@ -1616,8 +1582,7 @@
     "category": "flight",
     "returnType": "string",
     "params": "string mode",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.setThrottle",
@@ -1639,8 +1604,7 @@
     "category": "flight",
     "returnType": "int",
     "params": "float trim",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.stage",
@@ -1660,8 +1624,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.throttleDown",
@@ -1708,8 +1671,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.yawInput",
@@ -1720,8 +1682,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.yawTrim",
@@ -1732,8 +1693,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.yInput",
@@ -1744,8 +1704,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.zInput",
@@ -1756,8 +1715,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "far.aoa",
@@ -1769,8 +1727,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.available",
@@ -1782,8 +1739,7 @@
     "category": "far",
     "returnType": "bool",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.ballisticCoeff",
@@ -1795,8 +1751,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.decreaseFlaps",
@@ -1808,8 +1763,7 @@
     "category": "far",
     "returnType": "bool",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.dragCoeff",
@@ -1821,8 +1775,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.dynPres",
@@ -1834,8 +1787,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.flapSetting",
@@ -1847,8 +1799,7 @@
     "category": "far",
     "returnType": "int",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.increaseFlaps",
@@ -1860,8 +1811,7 @@
     "category": "far",
     "returnType": "bool",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.liftCoeff",
@@ -1873,8 +1823,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.refArea",
@@ -1886,8 +1835,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.setSpoilers",
@@ -1900,8 +1848,7 @@
     "returnType": "bool",
     "params": "bool active",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.sideslip",
@@ -1913,8 +1860,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.spoiler",
@@ -1926,8 +1872,7 @@
     "category": "far",
     "returnType": "bool",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.stallFrac",
@@ -1939,8 +1884,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.termVel",
@@ -1952,8 +1896,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.tsfc",
@@ -1965,8 +1908,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.voxelized",
@@ -1978,8 +1920,107 @@
     "category": "far",
     "returnType": "bool",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
+  },
+  {
+    "key": "kc.crewRoster",
+    "description": "Whole-program kerbal roster — name, trait, type, gender, experience, experienceLevel, courage, stupidity, isBadass, veteran, careerFlights, careerEntries, currentVesselId, currentVesselName, available, unavailableReason",
+    "units": "UNITLESS",
+    "plotable": false,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "ksc",
+    "returnType": "object",
+    "declaringClass": "KscDataLinkHandler"
+  },
+  {
+    "key": "kc.facilityLevels",
+    "description": "Per-facility { level, max, upgradeFunds } for the 9 stock SC buildings",
+    "units": "UNITLESS",
+    "plotable": false,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "ksc",
+    "returnType": "object",
+    "declaringClass": "KscDataLinkHandler"
+  },
+  {
+    "key": "kc.launchSite",
+    "description": "Active flight's launch site name",
+    "units": "STRING",
+    "plotable": true,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "ksc",
+    "returnType": "string",
+    "declaringClass": "KscDataLinkHandler"
+  },
+  {
+    "key": "kc.padOccupied",
+    "description": "True iff the active vessel is in PRELAUNCH situation",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "ksc",
+    "returnType": "bool",
+    "declaringClass": "KscDataLinkHandler"
+  },
+  {
+    "key": "kc.padVesselTitle",
+    "description": "Vessel name when on the pad; empty otherwise",
+    "units": "STRING",
+    "plotable": true,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "ksc",
+    "returnType": "string",
+    "declaringClass": "KscDataLinkHandler"
+  },
+  {
+    "key": "kc.partsAvailable",
+    "description": "Number of parts purchasable under current tech",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "ksc",
+    "returnType": "int",
+    "declaringClass": "KscDataLinkHandler"
+  },
+  {
+    "key": "kc.savedShips",
+    "description": "Saved craft files in VAB+SPH — name, partCount, totalMass, facility, requiresFunds, missingParts",
+    "units": "UNITLESS",
+    "plotable": false,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "ksc",
+    "returnType": "object",
+    "declaringClass": "KscDataLinkHandler"
+  },
+  {
+    "key": "kc.scene",
+    "description": "Current KSP scene (Flight, SpaceCenter, Editor, TrackingStation, MainMenu, Other)",
+    "units": "STRING",
+    "plotable": true,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "ksc",
+    "returnType": "string",
+    "declaringClass": "KscDataLinkHandler"
+  },
+  {
+    "key": "kc.upgradeFacility",
+    "description": "Upgrade a SC facility by short name (launchPad, vab, sph, …)",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": true,
+    "alwaysEvaluable": true,
+    "category": "ksc",
+    "returnType": "object",
+    "params": "string facilityShortName",
+    "declaringClass": "KscDataLinkHandler"
   },
   {
     "key": "kerbalism.available",
@@ -1991,8 +2032,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.breathable",
@@ -2004,8 +2044,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.co2Level",
@@ -2017,8 +2056,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.connection",
@@ -2030,8 +2068,7 @@
     "category": "kerbalism",
     "returnType": "object",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.connectionLinked",
@@ -2043,8 +2080,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.connectionRate",
@@ -2056,8 +2092,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.connectionTransmitting",
@@ -2069,8 +2104,7 @@
     "category": "kerbalism",
     "returnType": "int",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.crew",
@@ -2082,8 +2116,7 @@
     "category": "kerbalism",
     "returnType": "object",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.critical",
@@ -2095,8 +2128,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.drivesCapacity",
@@ -2108,8 +2140,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.drivesFreeSpace",
@@ -2121,8 +2152,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.envStormRadiation",
@@ -2134,8 +2164,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.envTempDiff",
@@ -2147,8 +2176,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.envTemperature",
@@ -2160,8 +2188,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.experimentRunning",
@@ -2173,8 +2200,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.features",
@@ -2186,8 +2212,7 @@
     "category": "kerbalism",
     "returnType": "object",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatComfort",
@@ -2199,8 +2224,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatLivingSpace",
@@ -2212,8 +2236,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatPressure",
@@ -2225,8 +2248,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatRadiation",
@@ -2238,8 +2260,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatSurface",
@@ -2251,8 +2272,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatVolume",
@@ -2264,8 +2284,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.inAtmosphere",
@@ -2277,8 +2296,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.innerBelt",
@@ -2290,8 +2308,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.magnetosphere",
@@ -2303,8 +2320,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.malfunction",
@@ -2316,8 +2332,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.outerBelt",
@@ -2329,8 +2344,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.radiation",
@@ -2342,8 +2356,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.radiationEnabled",
@@ -2355,8 +2368,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.radiationShielding",
@@ -2368,8 +2380,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.solarExposure",
@@ -2381,8 +2392,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarActivity",
@@ -2394,8 +2404,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarStormDuration",
@@ -2407,8 +2416,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarStormIncoming",
@@ -2420,8 +2428,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarStormInProgress",
@@ -2433,8 +2440,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarStormStartTime",
@@ -2446,8 +2452,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarStormState",
@@ -2459,8 +2464,108 @@
     "category": "kerbalism",
     "returnType": "int",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
+  },
+  {
+    "key": "ksp.canRevert",
+    "description": "Whether any revert path is available right now (post-init snapshot OR prelaunch snapshot). Mirrors FlightDriver.CanRevert.",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "launch",
+    "returnType": "bool",
+    "declaringClass": "LaunchDataLinkHandler"
+  },
+  {
+    "key": "ksp.canRevertToEditor",
+    "description": "Whether ksp.revertToEditor would currently succeed (FlightDriver.CanRevertToPrelaunch). Useful for graying out the revert-to-editor UI when the snapshot isn't available.",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "launch",
+    "returnType": "bool",
+    "declaringClass": "LaunchDataLinkHandler"
+  },
+  {
+    "key": "ksp.canRevertToLaunch",
+    "description": "Whether ksp.revertToLaunch would currently succeed (FlightDriver.CanRevertToPostInit). Useful for graying out the revert-to-launch UI when the snapshot isn't available.",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "launch",
+    "returnType": "bool",
+    "declaringClass": "LaunchDataLinkHandler"
+  },
+  {
+    "key": "ksp.launch",
+    "description": "Load a saved craft to the chosen pad (shipName, facility, site, crewSemicolons). Refuses outside SC/Editor, refuses if an active vessel exists.",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": true,
+    "alwaysEvaluable": true,
+    "category": "launch",
+    "returnType": "object",
+    "params": "string shipName, string facility, string site, string crewSemicolons",
+    "declaringClass": "LaunchDataLinkHandler"
+  },
+  {
+    "key": "ksp.recover",
+    "description": "Recover the active vessel — only valid in PRELAUNCH / LANDED / SPLASHED",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": true,
+    "alwaysEvaluable": false,
+    "category": "launch",
+    "returnType": "object",
+    "declaringClass": "LaunchDataLinkHandler"
+  },
+  {
+    "key": "ksp.revertToEditor",
+    "description": "Revert flight back to the named editor scene (vab|sph)",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": true,
+    "alwaysEvaluable": false,
+    "category": "launch",
+    "returnType": "object",
+    "params": "string editor",
+    "declaringClass": "LaunchDataLinkHandler"
+  },
+  {
+    "key": "ksp.revertToLaunch",
+    "description": "Revert flight to the just-launched state (vessel back on pad, PRELAUNCH situation). Same as the Flight Results dialog's 'Revert to Launch' button. Refuses outside Flight scene or when the post-init snapshot isn't available.",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": true,
+    "alwaysEvaluable": true,
+    "category": "launch",
+    "returnType": "object",
+    "declaringClass": "LaunchDataLinkHandler"
+  },
+  {
+    "key": "ksp.toSpaceCenter",
+    "description": "Switch to the Space Center scene. Mirrors the Flight Results dialog's 'Space Center' button.",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": true,
+    "alwaysEvaluable": true,
+    "category": "launch",
+    "returnType": "object",
+    "declaringClass": "LaunchDataLinkHandler"
+  },
+  {
+    "key": "ksp.toTrackingStation",
+    "description": "Switch to the Tracking Station scene. Mirrors the Flight Results dialog's 'Tracking Station' button.",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": true,
+    "alwaysEvaluable": true,
+    "category": "launch",
+    "returnType": "object",
+    "declaringClass": "LaunchDataLinkHandler"
   },
   {
     "key": "land.bestSpeedAtImpact",
@@ -2471,8 +2576,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.predictedAlt",
@@ -2483,8 +2587,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.predictedLat",
@@ -2495,8 +2598,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.predictedLon",
@@ -2507,8 +2609,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.slopeAngle",
@@ -2519,8 +2620,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.speedAtImpact",
@@ -2531,8 +2631,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.suicideBurnCountdown",
@@ -2543,8 +2642,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.timeToImpact",
@@ -2555,8 +2653,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "m.mapIsEnabled",
@@ -2567,8 +2664,7 @@
     "alwaysEvaluable": false,
     "category": "map",
     "returnType": "bool",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "mj.available",
@@ -2580,8 +2676,7 @@
     "category": "mechjeb",
     "returnType": "bool",
     "requiresMod": "mechjeb",
-    "declaringClass": "MechJebDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/MechJebDataLinkHandler.cs"
+    "declaringClass": "MechJebDataLinkHandler"
   },
   {
     "key": "mj.node",
@@ -2764,8 +2859,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.heading2",
@@ -2776,8 +2870,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.pitch",
@@ -2788,8 +2881,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.pitch2",
@@ -2800,8 +2892,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawheading",
@@ -2812,8 +2903,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawheading2",
@@ -2824,8 +2914,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawpitch",
@@ -2836,8 +2925,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawpitch2",
@@ -2848,8 +2936,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawroll",
@@ -2860,8 +2947,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawroll2",
@@ -2872,8 +2958,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.roll",
@@ -2884,8 +2969,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.roll2",
@@ -2896,8 +2980,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "o.addManeuverNode",
@@ -2910,8 +2993,7 @@
     "returnType": "object",
     "params": "float ut, float x, float y, float z",
     "formatter": "ManeuverNode",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.anVec",
@@ -2923,8 +3005,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.ApA",
@@ -2935,8 +3016,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.ApR",
@@ -2947,8 +3027,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.argumentOfPeriapsis",
@@ -2959,8 +3038,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.closestEncounterBody",
@@ -2971,8 +3049,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.closestTgtApprUT",
@@ -2983,8 +3060,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.eccentricAnomaly",
@@ -2995,8 +3071,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.eccentricity",
@@ -3007,8 +3082,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.eccVec",
@@ -3020,8 +3094,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.encounterBody",
@@ -3032,8 +3105,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.encounterExists",
@@ -3044,8 +3116,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "int",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.encounterTime",
@@ -3056,8 +3127,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.EndUT",
@@ -3068,8 +3138,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.epoch",
@@ -3080,8 +3149,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.gameLanguage",
@@ -3092,8 +3160,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "LangDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "LangDataLinkHandler"
   },
   {
     "key": "o.h",
@@ -3105,8 +3172,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.inclination",
@@ -3117,8 +3183,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.lan",
@@ -3129,8 +3194,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.maae",
@@ -3141,8 +3205,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes",
@@ -3154,8 +3217,7 @@
     "category": "maneuver",
     "returnType": "object",
     "formatter": "ManeuverNodeList",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.burnVector",
@@ -3168,8 +3230,7 @@
     "returnType": "Vector3d",
     "params": "int id",
     "formatter": "Vector3d",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.count",
@@ -3180,8 +3241,7 @@
     "alwaysEvaluable": false,
     "category": "maneuver",
     "returnType": "int",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.deltaV",
@@ -3194,8 +3254,7 @@
     "returnType": "Vector3d",
     "params": "int id",
     "formatter": "Vector3d",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.deltaVMagnitude",
@@ -3207,8 +3266,7 @@
     "category": "maneuver",
     "returnType": "double",
     "params": "int id",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.orbitPatches",
@@ -3221,8 +3279,7 @@
     "returnType": "object",
     "params": "int id",
     "formatter": "OrbitPatchList",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.relativePositionAtTrueAnomalyForManeuverNodesOrbitPatch",
@@ -3235,8 +3292,7 @@
     "returnType": "Vector3d",
     "params": "int id, int patchIndex, double trueAnomaly",
     "formatter": "Vector3d",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.relativePositionAtUTForManeuverNodesOrbitPatch",
@@ -3249,8 +3305,7 @@
     "returnType": "Vector3d",
     "params": "int id, int patchIndex, double UT",
     "formatter": "Vector3d",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.timeTo",
@@ -3262,8 +3317,7 @@
     "category": "maneuver",
     "returnType": "double",
     "params": "int id",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.trueAnomalyAtUTForManeuverNodesOrbitPatch",
@@ -3275,8 +3329,7 @@
     "category": "maneuver",
     "returnType": "double",
     "params": "int id, int patchIndex, double UT",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.UT",
@@ -3288,8 +3341,7 @@
     "category": "maneuver",
     "returnType": "double",
     "params": "int id",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.UTForTrueAnomalyForManeuverNodesOrbitPatch",
@@ -3301,8 +3353,7 @@
     "category": "maneuver",
     "returnType": "double",
     "params": "int id, int patchIndex, double trueAnomaly",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.mean.anomalisticPeriod",
@@ -3314,8 +3365,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.ApA",
@@ -3327,8 +3377,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.ApARange",
@@ -3340,8 +3389,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.argumentOfPeriapsis",
@@ -3353,8 +3401,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.eccentricity",
@@ -3366,8 +3413,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.eccentricityRange",
@@ -3379,8 +3425,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.inclination",
@@ -3392,8 +3437,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.inclinationRange",
@@ -3405,8 +3449,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.lan",
@@ -3418,8 +3461,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.nodalPeriod",
@@ -3431,8 +3473,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.nodalPrecession",
@@ -3444,8 +3485,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.PeA",
@@ -3457,8 +3497,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.PeARange",
@@ -3470,8 +3509,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.recurrence",
@@ -3483,8 +3521,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.siderealPeriod",
@@ -3496,8 +3533,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.sma",
@@ -3509,8 +3545,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.smaRange",
@@ -3522,8 +3557,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.meanAnomaly",
@@ -3534,8 +3568,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.nextApsisType",
@@ -3546,8 +3579,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitalEnergy",
@@ -3558,8 +3590,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitalSpeed",
@@ -3570,8 +3601,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitalSpeedAt",
@@ -3583,8 +3613,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "double obt",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitalSpeedAtDistance",
@@ -3596,8 +3625,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "double distance",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitNormal",
@@ -3609,8 +3637,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitPatches",
@@ -3622,8 +3649,7 @@
     "category": "orbit",
     "returnType": "object",
     "formatter": "OrbitPatchList",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitPercent",
@@ -3634,8 +3660,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.patchEndTransition",
@@ -3646,8 +3671,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.patchStartTransition",
@@ -3658,8 +3682,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.PeA",
@@ -3670,8 +3693,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.PeR",
@@ -3682,8 +3704,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.period",
@@ -3694,8 +3715,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.pos",
@@ -3707,8 +3727,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.radius",
@@ -3719,8 +3738,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.radiusAtTrueAnomaly",
@@ -3732,8 +3750,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "double trueAnomaly",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.referenceBody",
@@ -3744,8 +3761,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.relativePositionAtTrueAnomalyForOrbitPatch",
@@ -3758,8 +3774,7 @@
     "returnType": "Vector3d",
     "params": "int patchIndex, double trueAnomaly",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.relativePositionAtUTForOrbitPatch",
@@ -3772,8 +3787,7 @@
     "returnType": "Vector3d",
     "params": "int patchIndex, double UT",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.relativeVelocity",
@@ -3784,8 +3798,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.removeManeuverNode",
@@ -3797,8 +3810,7 @@
     "category": "maneuver",
     "returnType": "bool",
     "params": "int id",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.semiLatusRectum",
@@ -3809,8 +3821,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.semiMinorAxis",
@@ -3821,8 +3832,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.sma",
@@ -3833,8 +3843,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.StartUT",
@@ -3845,8 +3854,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeOfPeriapsisPassage",
@@ -3857,8 +3865,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeToAp",
@@ -3869,8 +3876,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeToNextApsis",
@@ -3881,8 +3887,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeToPe",
@@ -3893,8 +3898,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeToTransition1",
@@ -3905,8 +3909,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeToTransition2",
@@ -3917,8 +3920,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.trueAnomaly",
@@ -3929,8 +3931,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.trueAnomalyAtRadius",
@@ -3942,8 +3943,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "double radius",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.trueAnomalyAtUTForOrbitPatch",
@@ -3955,8 +3955,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "int patchIndex, double UT",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.updateManeuverNode",
@@ -3969,8 +3968,7 @@
     "returnType": "object",
     "params": "int id, float ut, float x, float y, float z",
     "formatter": "ManeuverNode",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.UTForTrueAnomalyForOrbitPatch",
@@ -3982,8 +3980,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "int patchIndex, double trueAnomaly",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.UTsoi",
@@ -3994,8 +3991,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.vel",
@@ -4007,8 +4003,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "p.paused",
@@ -4019,8 +4014,7 @@
     "alwaysEvaluable": true,
     "category": "system",
     "returnType": "int",
-    "declaringClass": "PausedDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/SystemHandlers.cs"
+    "declaringClass": "PausedDataLinkHandler"
   },
   {
     "key": "principia.active",
@@ -4032,8 +4026,7 @@
     "category": "principia",
     "returnType": "bool",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.analysis",
@@ -4045,8 +4038,7 @@
     "category": "principia",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.analysisProgress",
@@ -4058,8 +4050,7 @@
     "category": "principia",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.available",
@@ -4071,8 +4062,7 @@
     "category": "principia",
     "returnType": "bool",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.missionDuration",
@@ -4084,8 +4074,7 @@
     "category": "principia",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.plan.burn",
@@ -4098,8 +4087,7 @@
     "returnType": "object",
     "params": "int index",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.plan.burns",
@@ -4111,8 +4099,7 @@
     "category": "principia",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.plan.count",
@@ -4124,8 +4111,7 @@
     "category": "principia",
     "returnType": "int",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.plan.guidance",
@@ -4137,8 +4123,7 @@
     "category": "principia",
     "returnType": "bool",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.version",
@@ -4150,8 +4135,7 @@
     "category": "principia",
     "returnType": "string",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "r.resource",
@@ -4164,8 +4148,7 @@
     "returnType": "object",
     "params": "string resourceName",
     "formatter": "ResourceList",
-    "declaringClass": "ResourceDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "ResourceDataLinkHandler"
   },
   {
     "key": "r.resourceCurrent",
@@ -4178,8 +4161,7 @@
     "returnType": "object",
     "params": "string resourceName",
     "formatter": "ActiveResourceList",
-    "declaringClass": "ResourceDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "ResourceDataLinkHandler"
   },
   {
     "key": "r.resourceCurrentMax",
@@ -4192,8 +4174,7 @@
     "returnType": "object",
     "params": "string resourceName",
     "formatter": "MaxCurrentResourceList",
-    "declaringClass": "ResourceDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "ResourceDataLinkHandler"
   },
   {
     "key": "r.resourceMax",
@@ -4206,8 +4187,7 @@
     "returnType": "object",
     "params": "string resourceName",
     "formatter": "MaxResourceList",
-    "declaringClass": "ResourceDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "ResourceDataLinkHandler"
   },
   {
     "key": "r.resourceNameList",
@@ -4219,8 +4199,7 @@
     "category": "resource",
     "returnType": "string[]",
     "formatter": "StringArray",
-    "declaringClass": "ResourceDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "ResourceDataLinkHandler"
   },
   {
     "key": "rc.anyDeployed",
@@ -4232,8 +4211,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.arm",
@@ -4245,8 +4223,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.available",
@@ -4258,8 +4235,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.chutes",
@@ -4271,8 +4247,7 @@
     "category": "realchute",
     "returnType": "object",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.count",
@@ -4284,8 +4259,7 @@
     "category": "realchute",
     "returnType": "int",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.cut",
@@ -4297,8 +4271,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.deploy",
@@ -4310,8 +4283,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.disarm",
@@ -4323,8 +4295,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.safeState",
@@ -4336,8 +4307,7 @@
     "category": "realchute",
     "returnType": "string",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "s.sensor",
@@ -4350,8 +4320,7 @@
     "returnType": "object",
     "params": "string sensorType",
     "formatter": "SensorModuleList",
-    "declaringClass": "SensorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "SensorDataLinkHandler"
   },
   {
     "key": "s.sensor.acc",
@@ -4363,8 +4332,7 @@
     "category": "sensor",
     "returnType": "object",
     "formatter": "SensorModuleList",
-    "declaringClass": "SensorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "SensorDataLinkHandler"
   },
   {
     "key": "s.sensor.grav",
@@ -4376,8 +4344,7 @@
     "category": "sensor",
     "returnType": "object",
     "formatter": "SensorModuleList",
-    "declaringClass": "SensorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "SensorDataLinkHandler"
   },
   {
     "key": "s.sensor.pres",
@@ -4389,8 +4356,7 @@
     "category": "sensor",
     "returnType": "object",
     "formatter": "SensorModuleList",
-    "declaringClass": "SensorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "SensorDataLinkHandler"
   },
   {
     "key": "s.sensor.temp",
@@ -4402,8 +4368,29 @@
     "category": "sensor",
     "returnType": "object",
     "formatter": "SensorModuleList",
-    "declaringClass": "SensorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "SensorDataLinkHandler"
+  },
+  {
+    "key": "sci.canRecoverTotal",
+    "description": "Total dataAmount across all stored ScienceData on the active vessel (alias of canTransmitTotal — separate key in case Phase 4 formulas diverge)",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": false,
+    "alwaysEvaluable": false,
+    "category": "science",
+    "returnType": "double",
+    "declaringClass": "ScienceInstrumentsDataLinkHandler"
+  },
+  {
+    "key": "sci.canTransmitTotal",
+    "description": "Total dataAmount across all stored ScienceData on the active vessel",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": false,
+    "alwaysEvaluable": false,
+    "category": "science",
+    "returnType": "double",
+    "declaringClass": "ScienceInstrumentsDataLinkHandler"
   },
   {
     "key": "sci.count",
@@ -4414,8 +4401,7 @@
     "alwaysEvaluable": false,
     "category": "science",
     "returnType": "int",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "sci.dataAmount",
@@ -4426,8 +4412,42 @@
     "alwaysEvaluable": false,
     "category": "science",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
+  },
+  {
+    "key": "sci.deploy",
+    "description": "Run an experiment by part flightID (no result dialog — direct data capture)",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": true,
+    "alwaysEvaluable": false,
+    "category": "science",
+    "returnType": "object",
+    "params": "uint partId",
+    "declaringClass": "ScienceInstrumentsDataLinkHandler"
+  },
+  {
+    "key": "sci.dump",
+    "description": "Discard all stored data on the part without transmitting",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": true,
+    "alwaysEvaluable": false,
+    "category": "science",
+    "returnType": "object",
+    "params": "uint partId",
+    "declaringClass": "ScienceInstrumentsDataLinkHandler"
+  },
+  {
+    "key": "sci.experimentBreakdown",
+    "description": "Per-stored-data detail on the active vessel — subjectId / biome / situation / mits / transmit values / remaining potential",
+    "units": "UNITLESS",
+    "plotable": false,
+    "isAction": false,
+    "alwaysEvaluable": false,
+    "category": "science",
+    "returnType": "object",
+    "declaringClass": "ScienceInstrumentsDataLinkHandler"
   },
   {
     "key": "sci.experiments",
@@ -4438,8 +4458,42 @@
     "alwaysEvaluable": false,
     "category": "science",
     "returnType": "object",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
+  },
+  {
+    "key": "sci.instruments",
+    "description": "Per-instrument state on the active vessel (partId, partTitle, expId, deployed, hasData, rerunnable, inoperable)",
+    "units": "UNITLESS",
+    "plotable": false,
+    "isAction": false,
+    "alwaysEvaluable": false,
+    "category": "science",
+    "returnType": "object",
+    "declaringClass": "ScienceInstrumentsDataLinkHandler"
+  },
+  {
+    "key": "sci.reset",
+    "description": "Reset experiment — clears Deployed + drops data, makes rerunnable instruments ready to run again",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": true,
+    "alwaysEvaluable": false,
+    "category": "science",
+    "returnType": "object",
+    "params": "uint partId",
+    "declaringClass": "ScienceInstrumentsDataLinkHandler"
+  },
+  {
+    "key": "sci.transmit",
+    "description": "Transmit stored data on the part via the active vessel's best transmitter",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": true,
+    "alwaysEvaluable": false,
+    "category": "science",
+    "returnType": "object",
+    "params": "uint partId",
+    "declaringClass": "ScienceInstrumentsDataLinkHandler"
   },
   {
     "key": "t.currentRate",
@@ -4450,8 +4504,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "double",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.currentRateIndex",
@@ -4462,8 +4515,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "double",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.deltaTime",
@@ -4474,8 +4526,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "double",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.isPaused",
@@ -4486,8 +4537,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "bool",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.maxPhysicsRate",
@@ -4498,8 +4548,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "double",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.universalTime",
@@ -4510,8 +4559,7 @@
     "alwaysEvaluable": true,
     "category": "timewarp",
     "returnType": "double",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.warpMode",
@@ -4522,8 +4570,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "string",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "tar.clearTarget",
@@ -4534,8 +4581,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "int",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.distance",
@@ -4546,8 +4592,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.groundDistance",
@@ -4558,8 +4603,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.name",
@@ -4570,8 +4614,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "string",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.ApA",
@@ -4582,8 +4625,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.argumentOfPeriapsis",
@@ -4594,8 +4636,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.eccentricity",
@@ -4606,8 +4647,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.inclination",
@@ -4618,8 +4658,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.lan",
@@ -4630,8 +4669,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.maae",
@@ -4642,8 +4680,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.orbitingBody",
@@ -4654,8 +4691,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "string",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.orbitPatches",
@@ -4667,8 +4703,7 @@
     "category": "target",
     "returnType": "double",
     "formatter": "OrbitPatchList",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.PeA",
@@ -4679,8 +4714,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.period",
@@ -4691,8 +4725,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.relativeInclination",
@@ -4703,8 +4736,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.relativePositionAtTrueAnomalyForOrbitPatch",
@@ -4717,8 +4749,7 @@
     "returnType": "double",
     "params": "int orbitPatchIndex, float trueAnomaly",
     "formatter": "Vector3d",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.relativePositionAtUTForOrbitPatch",
@@ -4731,8 +4762,7 @@
     "returnType": "double",
     "params": "int orbitPatchIndex, double universalTime",
     "formatter": "Vector3d",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.relativeVelocity",
@@ -4743,8 +4773,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.sma",
@@ -4755,8 +4784,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.timeOfPeriapsisPassage",
@@ -4767,8 +4795,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.timeToAp",
@@ -4779,8 +4806,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.timeToPe",
@@ -4791,8 +4817,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.timeToTransition1",
@@ -4803,8 +4828,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.timeToTransition2",
@@ -4815,8 +4839,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.trueAnomaly",
@@ -4827,8 +4850,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.trueAnomalyAtUTForOrbitPatch",
@@ -4840,8 +4862,7 @@
     "category": "target",
     "returnType": "double",
     "params": "int orbitPatchIndex, float universalTime",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.UTForTrueAnomalyForOrbitPatch",
@@ -4853,8 +4874,7 @@
     "category": "target",
     "returnType": "double",
     "params": "int orbitPatchIndex, float trueAnomaly",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.velocity",
@@ -4865,8 +4885,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.setTargetBody",
@@ -4878,8 +4897,7 @@
     "category": "target",
     "returnType": "int",
     "params": "int bodyId",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.setTargetVessel",
@@ -4891,8 +4909,7 @@
     "category": "target",
     "returnType": "int",
     "params": "int vesselIndex",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.type",
@@ -4903,8 +4920,52 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "string",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
+  },
+  {
+    "key": "tech.affordable",
+    "description": "Tech-tree nodes affordable right now (not yet unlocked, scienceCost <= current science)",
+    "units": "UNITLESS",
+    "plotable": false,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "career",
+    "returnType": "object",
+    "declaringClass": "TechTreeDataLinkHandler"
+  },
+  {
+    "key": "tech.unlock",
+    "description": "Unlock a tech-tree node — deducts science, marks node Available",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": true,
+    "alwaysEvaluable": true,
+    "category": "career",
+    "returnType": "object",
+    "params": "string techId",
+    "declaringClass": "TechTreeDataLinkHandler"
+  },
+  {
+    "key": "tech.unlockedIds",
+    "description": "Tech-tree node ids the player has researched",
+    "units": "UNITLESS",
+    "plotable": false,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "career",
+    "returnType": "object",
+    "declaringClass": "TechTreeDataLinkHandler"
+  },
+  {
+    "key": "tech.unlockedPartCount",
+    "description": "Number of parts purchasable under current tech",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "career",
+    "returnType": "int",
+    "declaringClass": "TechTreeDataLinkHandler"
   },
   {
     "key": "therm.anyEnginesOverheating",
@@ -4915,8 +4976,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "bool",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.heatShieldFlux",
@@ -4927,8 +4987,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.heatShieldTemp",
@@ -4939,8 +4998,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.heatShieldTempCelsius",
@@ -4951,8 +5009,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestEngineMaxTemp",
@@ -4963,8 +5020,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestEngineTemp",
@@ -4975,8 +5031,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestEngineTempRatio",
@@ -4987,8 +5042,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestPartMaxTemp",
@@ -4999,8 +5053,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestPartName",
@@ -5011,8 +5064,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "string",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestPartTemp",
@@ -5023,8 +5075,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestPartTempKelvin",
@@ -5035,8 +5086,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestPartTempRatio",
@@ -5047,8 +5097,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "v.abortValue",
@@ -5059,8 +5108,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.acceleration",
@@ -5071,8 +5119,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.accelerationx",
@@ -5083,8 +5130,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.accelerationy",
@@ -5095,8 +5141,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.accelerationz",
@@ -5107,8 +5152,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.ag10Value",
@@ -5119,8 +5163,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag1Value",
@@ -5131,8 +5174,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag2Value",
@@ -5143,8 +5185,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag3Value",
@@ -5155,8 +5196,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag4Value",
@@ -5167,8 +5207,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag5Value",
@@ -5179,8 +5218,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag6Value",
@@ -5191,8 +5229,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag7Value",
@@ -5203,8 +5240,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag8Value",
@@ -5215,8 +5251,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag9Value",
@@ -5227,8 +5262,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.altitude",
@@ -5239,8 +5273,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angleToPrograde",
@@ -5251,8 +5284,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularMomentum",
@@ -5263,8 +5295,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularMomentumx",
@@ -5275,8 +5306,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularMomentumy",
@@ -5287,8 +5317,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularMomentumz",
@@ -5299,8 +5328,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularVelocity",
@@ -5311,8 +5339,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularVelocityx",
@@ -5323,8 +5350,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularVelocityy",
@@ -5335,8 +5361,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularVelocityz",
@@ -5347,8 +5372,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.atmosphericDensity",
@@ -5359,8 +5383,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.atmosphericPressure",
@@ -5371,8 +5394,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.atmosphericPressurePa",
@@ -5383,8 +5405,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.atmosphericTemperature",
@@ -5395,8 +5416,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.biome",
@@ -5407,8 +5427,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.biomeLocalized",
@@ -5419,8 +5438,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.body",
@@ -5431,8 +5449,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.brakeValue",
@@ -5443,8 +5460,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.CoM",
@@ -5456,8 +5472,7 @@
     "category": "vessel",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.crew",
@@ -5469,8 +5484,7 @@
     "category": "vessel",
     "returnType": "string[]",
     "formatter": "StringArray",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.crewCapacity",
@@ -5481,8 +5495,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "int",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.crewCount",
@@ -5493,8 +5506,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "int",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.currentStage",
@@ -5505,8 +5517,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "int",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.directSunlight",
@@ -5517,8 +5528,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.distanceToSun",
@@ -5529,8 +5539,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.dynamicPressure",
@@ -5541,8 +5550,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.dynamicPressurekPa",
@@ -5553,8 +5561,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.externalTemperature",
@@ -5565,8 +5572,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.gearValue",
@@ -5577,8 +5583,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.geeForce",
@@ -5589,8 +5594,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.geeForceImmediate",
@@ -5601,8 +5605,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.heightFromSurface",
@@ -5613,8 +5616,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.heightFromTerrain",
@@ -5625,8 +5627,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.indicatedAirSpeed",
@@ -5637,8 +5638,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.isActiveVessel",
@@ -5649,8 +5649,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.isCommandable",
@@ -5661,8 +5660,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.isControllable",
@@ -5673,8 +5671,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.isEVA",
@@ -5685,8 +5682,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.landed",
@@ -5697,8 +5693,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.landedAt",
@@ -5709,8 +5704,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.landedOrSplashed",
@@ -5721,8 +5715,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.lat",
@@ -5733,8 +5726,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.launchTime",
@@ -5745,8 +5737,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.lightValue",
@@ -5757,8 +5748,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.loaded",
@@ -5769,8 +5759,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.long",
@@ -5781,8 +5770,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.mach",
@@ -5793,8 +5781,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.mass",
@@ -5805,8 +5792,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.missionTime",
@@ -5817,8 +5803,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.missionTimeString",
@@ -5829,8 +5814,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.momentOfInertia",
@@ -5842,8 +5826,7 @@
     "category": "vessel",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.name",
@@ -5854,8 +5837,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.obtSpeed",
@@ -5866,8 +5848,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.orbitalVelocity",
@@ -5878,8 +5859,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.orbitalVelocityx",
@@ -5890,8 +5870,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.orbitalVelocityy",
@@ -5902,8 +5881,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.orbitalVelocityz",
@@ -5914,8 +5892,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.packed",
@@ -5926,8 +5903,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.perturbation",
@@ -5938,8 +5914,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.perturbationx",
@@ -5950,8 +5925,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.perturbationy",
@@ -5962,8 +5936,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.perturbationz",
@@ -5974,8 +5947,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.pqsAltitude",
@@ -5986,8 +5958,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.precisionControlValue",
@@ -5998,8 +5969,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.rcsValue",
@@ -6010,8 +5980,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.sasValue",
@@ -6022,8 +5991,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.setAttitude",
@@ -6035,8 +6003,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float pitch, float yaw, float roll",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setFbW",
@@ -6048,8 +6015,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "int state",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setPitch",
@@ -6061,8 +6027,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float pitch",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setPitchYawRollXYZ",
@@ -6074,8 +6039,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float pitch, float yaw, float roll, float x, float y, float z",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setRoll",
@@ -6087,8 +6051,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float roll",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setTranslation",
@@ -6100,8 +6063,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float x, float y, float z",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setYaw",
@@ -6113,8 +6075,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float yaw",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.situation",
@@ -6125,8 +6086,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.situationString",
@@ -6137,8 +6097,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.solarFlux",
@@ -6149,8 +6108,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.specificAcceleration",
@@ -6161,8 +6119,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.speed",
@@ -6173,8 +6130,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.speedOfSound",
@@ -6185,8 +6141,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.splashed",
@@ -6197,8 +6152,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.srfSpeed",
@@ -6209,8 +6163,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.staticPressure",
@@ -6221,8 +6174,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.staticPressurekPa",
@@ -6233,8 +6185,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.surfaceSpeed",
@@ -6245,8 +6196,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.surfaceVelocity",
@@ -6257,8 +6207,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.surfaceVelocityx",
@@ -6269,8 +6218,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.surfaceVelocityy",
@@ -6281,8 +6229,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.surfaceVelocityz",
@@ -6293,8 +6240,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.terrainHeight",
@@ -6305,8 +6251,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.terrainNormal",
@@ -6318,8 +6263,7 @@
     "category": "vessel",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.upAxis",
@@ -6331,8 +6275,7 @@
     "category": "vessel",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.verticalSpeed",
@@ -6343,8 +6286,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.vesselType",
@@ -6355,7 +6297,6 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   }
 ]

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -10512,6 +10512,86 @@ paths:
                   tech.unlockedPartCount:
                     type: integer
       x-plotable: true
+  "/api/strategies.all":
+    get:
+      summary: Every strategy with read-only fields plus canActivate / canDeactivate gates
+      operationId: strategies.all
+      tags:
+        - career
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  strategies.all:
+                    type: object
+  "/api/strategies.activate":
+    post:
+      summary: Activate a strategy by id at the given commitment factor (in any scene)
+      operationId: strategies.activate
+      tags:
+        - career
+      parameters:
+        - name: strategyId
+          in: query
+          required: true
+          description: Strategy config name (e.g. AggressiveNegotiations)
+          schema:
+            type: string
+        - name: factor
+          in: query
+          required: false
+          description: Commitment factor in [0, 1]
+          schema:
+            type: number
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  strategies.activate:
+                    type: object
+      x-plotable: true
+  "/api/strategies.deactivate":
+    post:
+      summary: Deactivate an active strategy by id (in any scene)
+      operationId: strategies.deactivate
+      tags:
+        - career
+      parameters:
+        - name: strategyId
+          in: query
+          required: true
+          description: Strategy config name
+          schema:
+            type: string
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  strategies.deactivate:
+                    type: object
+      x-plotable: true
   "/api/therm.anyEnginesOverheating":
     get:
       summary: Any Engine Near Overheat (>90%)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -10404,6 +10404,26 @@ paths:
                     type: string
       x-units: STRING
       x-plotable: true
+  "/api/tech.nodes":
+    get:
+      summary: Full tech tree — every node with id, title, description, scienceCost, state, parents, parts
+      operationId: tech.nodes
+      tags:
+        - career
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  tech.nodes:
+                    type: object
   "/api/tech.affordable":
     get:
       summary: Tech-tree nodes affordable right now (not yet unlocked, scienceCost <= current science)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -80,6 +80,8 @@ tags:
     description: Career
   - name: comms
     description: Communications
+  - name: control
+    description: control
   - name: deltav
     description: Delta-V
   - name: docking
@@ -94,8 +96,12 @@ tags:
   - name: kerbalism
     description: kerbalism
     x-requires-mod: kerbalism
+  - name: ksc
+    description: ksc
   - name: landing
     description: Landing Prediction
+  - name: launch
+    description: launch
   - name: maneuver
     description: Maneuver Nodes
   - name: map
@@ -2026,6 +2032,147 @@ paths:
                   comm.signalStrength:
                     type: number
       x-plotable: true
+  "/api/contracts.accept":
+    post:
+      summary: Accept an Offered contract (moves to Active)
+      operationId: contracts.accept
+      tags:
+        - career
+      parameters:
+        - name: contractId
+          in: query
+          required: true
+          description: long parameter (passed via bracket notation)
+          schema:
+            type: string
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  contracts.accept:
+                    type: object
+      x-plotable: true
+  "/api/contracts.active":
+    get:
+      summary: All Active contracts with parameters + reward shape
+      operationId: contracts.active
+      tags:
+        - career
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  contracts.active:
+                    type: object
+  "/api/contracts.cancel":
+    post:
+      summary: Cancel an Active contract — forfeits work in progress; only valid for Active
+      operationId: contracts.cancel
+      tags:
+        - career
+      parameters:
+        - name: contractId
+          in: query
+          required: true
+          description: long parameter (passed via bracket notation)
+          schema:
+            type: string
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  contracts.cancel:
+                    type: object
+      x-plotable: true
+  "/api/contracts.completedRecent":
+    get:
+      summary: Last N completed-or-failed contracts, newest-first
+      operationId: contracts.completedRecent
+      tags:
+        - career
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  contracts.completedRecent:
+                    type: object
+  "/api/contracts.decline":
+    post:
+      summary: Decline an Offered contract — different verb from cancel; only valid for Offered
+      operationId: contracts.decline
+      tags:
+        - career
+      parameters:
+        - name: contractId
+          in: query
+          required: true
+          description: long parameter (passed via bracket notation)
+          schema:
+            type: string
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  contracts.decline:
+                    type: object
+      x-plotable: true
+  "/api/contracts.offered":
+    get:
+      summary: Contracts in Mission Control awaiting accept
+      operationId: contracts.offered
+      tags:
+        - career
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  contracts.offered:
+                    type: object
   "/api/dock.ax":
     get:
       summary: Docking x Angle
@@ -2828,6 +2975,26 @@ paths:
                 properties:
                   f.abort:
                     type: integer
+  "/api/f.ag.bindings":
+    get:
+      summary: "Per-action flat list of action-group bindings on the active vessel: { actionGroup, partId, partName, partTitle, moduleName, actionName, actionGuiName }. One row per (action, group) pair — an action bound to two groups emits two rows. Actions with no group (None) are omitted."
+      operationId: f.ag.bindings
+      tags:
+        - control
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  f.ag.bindings:
+                    type: object
   "/api/f.ag1":
     post:
       summary: Action Group 1
@@ -4157,6 +4324,201 @@ paths:
                     type: boolean
       x-requires-mod: far
       x-plotable: true
+  "/api/kc.crewRoster":
+    get:
+      summary: Whole-program kerbal roster — name, trait, type, gender, experience, experienceLevel, courage, stupidity, isBadass, veteran, careerFlights, careerEntries, currentVesselId, currentVesselName, available, unavailableReason
+      operationId: kc.crewRoster
+      tags:
+        - ksc
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  kc.crewRoster:
+                    type: object
+  "/api/kc.facilityLevels":
+    get:
+      summary: "Per-facility { level, max, upgradeFunds } for the 9 stock SC buildings"
+      operationId: kc.facilityLevels
+      tags:
+        - ksc
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  kc.facilityLevels:
+                    type: object
+  "/api/kc.launchSite":
+    get:
+      summary: "Active flight's launch site name"
+      operationId: kc.launchSite
+      tags:
+        - ksc
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  kc.launchSite:
+                    type: string
+      x-units: STRING
+      x-plotable: true
+  "/api/kc.padOccupied":
+    get:
+      summary: True iff the active vessel is in PRELAUNCH situation
+      operationId: kc.padOccupied
+      tags:
+        - ksc
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  kc.padOccupied:
+                    type: boolean
+      x-plotable: true
+  "/api/kc.padVesselTitle":
+    get:
+      summary: Vessel name when on the pad; empty otherwise
+      operationId: kc.padVesselTitle
+      tags:
+        - ksc
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  kc.padVesselTitle:
+                    type: string
+      x-units: STRING
+      x-plotable: true
+  "/api/kc.partsAvailable":
+    get:
+      summary: Number of parts purchasable under current tech
+      operationId: kc.partsAvailable
+      tags:
+        - ksc
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  kc.partsAvailable:
+                    type: integer
+      x-plotable: true
+  "/api/kc.savedShips":
+    get:
+      summary: Saved craft files in VAB+SPH — name, partCount, totalMass, facility, requiresFunds, missingParts
+      operationId: kc.savedShips
+      tags:
+        - ksc
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  kc.savedShips:
+                    type: object
+  "/api/kc.scene":
+    get:
+      summary: Current KSP scene (Flight, SpaceCenter, Editor, TrackingStation, MainMenu, Other)
+      operationId: kc.scene
+      tags:
+        - ksc
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  kc.scene:
+                    type: string
+      x-units: STRING
+      x-plotable: true
+  "/api/kc.upgradeFacility":
+    post:
+      summary: Upgrade a SC facility by short name (launchPad, vab, sph, …)
+      operationId: kc.upgradeFacility
+      tags:
+        - ksc
+      parameters:
+        - name: facilityShortName
+          in: query
+          required: true
+          description: string parameter (passed via bracket notation)
+          schema:
+            type: string
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  kc.upgradeFacility:
+                    type: object
+      x-plotable: true
   "/api/kerbalism.available":
     get:
       summary: Kerbalism Is Installed
@@ -4967,6 +5329,225 @@ paths:
                   kerbalism.stellarStormState:
                     type: integer
       x-requires-mod: kerbalism
+      x-plotable: true
+  "/api/ksp.canRevert":
+    get:
+      summary: Whether any revert path is available right now (post-init snapshot OR prelaunch snapshot). Mirrors FlightDriver.CanRevert.
+      operationId: ksp.canRevert
+      tags:
+        - launch
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  ksp.canRevert:
+                    type: boolean
+      x-plotable: true
+  "/api/ksp.canRevertToEditor":
+    get:
+      summary: "Whether ksp.revertToEditor would currently succeed (FlightDriver.CanRevertToPrelaunch). Useful for graying out the revert-to-editor UI when the snapshot isn't available."
+      operationId: ksp.canRevertToEditor
+      tags:
+        - launch
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  ksp.canRevertToEditor:
+                    type: boolean
+      x-plotable: true
+  "/api/ksp.canRevertToLaunch":
+    get:
+      summary: "Whether ksp.revertToLaunch would currently succeed (FlightDriver.CanRevertToPostInit). Useful for graying out the revert-to-launch UI when the snapshot isn't available."
+      operationId: ksp.canRevertToLaunch
+      tags:
+        - launch
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  ksp.canRevertToLaunch:
+                    type: boolean
+      x-plotable: true
+  "/api/ksp.launch":
+    post:
+      summary: Load a saved craft to the chosen pad (shipName, facility, site, crewSemicolons). Refuses outside SC/Editor, refuses if an active vessel exists.
+      operationId: ksp.launch
+      tags:
+        - launch
+      parameters:
+        - name: shipName
+          in: query
+          required: true
+          description: string parameter (passed via bracket notation)
+          schema:
+            type: string
+        - name: facility
+          in: query
+          required: true
+          description: string parameter (passed via bracket notation)
+          schema:
+            type: string
+        - name: site
+          in: query
+          required: true
+          description: string parameter (passed via bracket notation)
+          schema:
+            type: string
+        - name: crewSemicolons
+          in: query
+          required: true
+          description: string parameter (passed via bracket notation)
+          schema:
+            type: string
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  ksp.launch:
+                    type: object
+      x-plotable: true
+  "/api/ksp.recover":
+    post:
+      summary: Recover the active vessel — only valid in PRELAUNCH / LANDED / SPLASHED
+      operationId: ksp.recover
+      tags:
+        - launch
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  ksp.recover:
+                    type: object
+      x-plotable: true
+  "/api/ksp.revertToEditor":
+    post:
+      summary: Revert flight back to the named editor scene (vab|sph)
+      operationId: ksp.revertToEditor
+      tags:
+        - launch
+      parameters:
+        - name: editor
+          in: query
+          required: true
+          description: string parameter (passed via bracket notation)
+          schema:
+            type: string
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  ksp.revertToEditor:
+                    type: object
+      x-plotable: true
+  "/api/ksp.revertToLaunch":
+    post:
+      summary: "Revert flight to the just-launched state (vessel back on pad, PRELAUNCH situation). Same as the Flight Results dialog's 'Revert to Launch' button. Refuses outside Flight scene or when the post-init snapshot isn't available."
+      operationId: ksp.revertToLaunch
+      tags:
+        - launch
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  ksp.revertToLaunch:
+                    type: object
+      x-plotable: true
+  "/api/ksp.toSpaceCenter":
+    post:
+      summary: "Switch to the Space Center scene. Mirrors the Flight Results dialog's 'Space Center' button."
+      operationId: ksp.toSpaceCenter
+      tags:
+        - launch
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  ksp.toSpaceCenter:
+                    type: object
+      x-plotable: true
+  "/api/ksp.toTrackingStation":
+    post:
+      summary: "Switch to the Tracking Station scene. Mirrors the Flight Results dialog's 'Tracking Station' button."
+      operationId: ksp.toTrackingStation
+      tags:
+        - launch
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  ksp.toTrackingStation:
+                    type: object
       x-plotable: true
   "/api/land.bestSpeedAtImpact":
     get:
@@ -8689,6 +9270,48 @@ paths:
                     type: object
       x-units: TEMP
       x-plotable: true
+  "/api/sci.canRecoverTotal":
+    get:
+      summary: Total dataAmount across all stored ScienceData on the active vessel (alias of canTransmitTotal — separate key in case Phase 4 formulas diverge)
+      operationId: sci.canRecoverTotal
+      tags:
+        - science
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  sci.canRecoverTotal:
+                    type: number
+      x-plotable: true
+  "/api/sci.canTransmitTotal":
+    get:
+      summary: Total dataAmount across all stored ScienceData on the active vessel
+      operationId: sci.canTransmitTotal
+      tags:
+        - science
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  sci.canTransmitTotal:
+                    type: number
+      x-plotable: true
   "/api/sci.count":
     get:
       summary: Number of Science Experiments Aboard
@@ -8731,6 +9354,80 @@ paths:
                   sci.dataAmount:
                     type: number
       x-plotable: true
+  "/api/sci.deploy":
+    post:
+      summary: Run an experiment by part flightID (no result dialog — direct data capture)
+      operationId: sci.deploy
+      tags:
+        - science
+      parameters:
+        - name: partId
+          in: query
+          required: true
+          description: uint parameter (passed via bracket notation)
+          schema:
+            type: string
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  sci.deploy:
+                    type: object
+      x-plotable: true
+  "/api/sci.dump":
+    post:
+      summary: Discard all stored data on the part without transmitting
+      operationId: sci.dump
+      tags:
+        - science
+      parameters:
+        - name: partId
+          in: query
+          required: true
+          description: uint parameter (passed via bracket notation)
+          schema:
+            type: string
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  sci.dump:
+                    type: object
+      x-plotable: true
+  "/api/sci.experimentBreakdown":
+    get:
+      summary: Per-stored-data detail on the active vessel — subjectId / biome / situation / mits / transmit values / remaining potential
+      operationId: sci.experimentBreakdown
+      tags:
+        - science
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  sci.experimentBreakdown:
+                    type: object
   "/api/sci.experiments":
     get:
       summary: Experiments With Data
@@ -8751,6 +9448,80 @@ paths:
                 properties:
                   sci.experiments:
                     type: object
+  "/api/sci.instruments":
+    get:
+      summary: Per-instrument state on the active vessel (partId, partTitle, expId, deployed, hasData, rerunnable, inoperable)
+      operationId: sci.instruments
+      tags:
+        - science
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  sci.instruments:
+                    type: object
+  "/api/sci.reset":
+    post:
+      summary: Reset experiment — clears Deployed + drops data, makes rerunnable instruments ready to run again
+      operationId: sci.reset
+      tags:
+        - science
+      parameters:
+        - name: partId
+          in: query
+          required: true
+          description: uint parameter (passed via bracket notation)
+          schema:
+            type: string
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  sci.reset:
+                    type: object
+      x-plotable: true
+  "/api/sci.transmit":
+    post:
+      summary: "Transmit stored data on the part via the active vessel's best transmitter"
+      operationId: sci.transmit
+      tags:
+        - science
+      parameters:
+        - name: partId
+          in: query
+          required: true
+          description: uint parameter (passed via bracket notation)
+          schema:
+            type: string
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  sci.transmit:
+                    type: object
+      x-plotable: true
   "/api/t.currentRate":
     get:
       summary: Current Warp Rate
@@ -9632,6 +10403,94 @@ paths:
                   tar.type:
                     type: string
       x-units: STRING
+      x-plotable: true
+  "/api/tech.affordable":
+    get:
+      summary: Tech-tree nodes affordable right now (not yet unlocked, scienceCost <= current science)
+      operationId: tech.affordable
+      tags:
+        - career
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  tech.affordable:
+                    type: object
+  "/api/tech.unlock":
+    post:
+      summary: Unlock a tech-tree node — deducts science, marks node Available
+      operationId: tech.unlock
+      tags:
+        - career
+      parameters:
+        - name: techId
+          in: query
+          required: true
+          description: string parameter (passed via bracket notation)
+          schema:
+            type: string
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  tech.unlock:
+                    type: object
+      x-plotable: true
+  "/api/tech.unlockedIds":
+    get:
+      summary: Tech-tree node ids the player has researched
+      operationId: tech.unlockedIds
+      tags:
+        - career
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  tech.unlockedIds:
+                    type: object
+  "/api/tech.unlockedPartCount":
+    get:
+      summary: Number of parts purchasable under current tech
+      operationId: tech.unlockedPartCount
+      tags:
+        - career
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  tech.unlockedPartCount:
+                    type: integer
       x-plotable: true
   "/api/therm.anyEnginesOverheating":
     get:

--- a/tools/generate-openapi.ts
+++ b/tools/generate-openapi.ts
@@ -481,7 +481,9 @@ const outPath = resolve(outDir, "openapi.yaml");
 writeFileSync(outPath, yaml + "\n");
 console.log(`Written ${outPath}`);
 
-// Also write the merged JSON for easy consumption
+// Also write the merged JSON for easy consumption.
+// `sourceFile` is omitted here — kept on the in-memory entries for tooling use, off the committed artifact.
 const mergedJsonPath = resolve(outDir, "api-schema.json");
-writeFileSync(mergedJsonPath, JSON.stringify(all, null, 2) + "\n");
+const sanitized = all.map(({ sourceFile: _sourceFile, ...rest }) => rest);
+writeFileSync(mergedJsonPath, JSON.stringify(sanitized, null, 2) + "\n");
 console.log(`Written ${mergedJsonPath}`);


### PR DESCRIPTION
⚠️ I've used Claude to make these changes and draft most of the description below. Built, tested locally in KSP, and happy with the result, so sharing here.

## Summary

Six new handlers + ~50 data keys covering more of the career-mode UI surface - useful for external dashboards that want to mirror or drive R&D, KSC, science, contracts, and launch/recovery from outside Flight. All new keys are `AlwaysEvaluable = true` so they're queryable from Space Center / Editor / Tracking Station.

Builds on #84 (now merged) for the `AlwaysEvaluable` attribute to take effect on the new action keys.

The branch has grown since the first review - a Strategies / Administration Building handler and a `CurrencyModifierQuery`-aware effective-cost layer have been added on top of the original six handlers. See "Updates since first review" below.

## New handlers

| Handler | Sample keys |
|---|---|
| `TechTreeDataLinkHandler` | `tech.nodes`, `tech.unlock[id]`, `tech.unlockedIds`, `tech.unlockedPartCount`, `tech.affordable` |
| `KscDataLinkHandler` | `kc.facilityLevels`, `kc.upgradeFacility[name]`, `kc.crewRoster`, `kc.scene`, `kc.savedShips`, `kc.partsAvailable` |
| `ScienceInstrumentsDataLinkHandler` | `sci.instruments`, `sci.experimentBreakdown`, `sci.experiments`, `sci.canRecoverTotal`, `sci.canTransmitTotal`, `sci.deploy[partFlightId, experimentId]`, `sci.transmit[partFlightId]` |
| `ContractsDataLinkHandler` | `contracts.active`, `contracts.offered`, `contracts.completedRecent`, `contracts.accept[id]`, `contracts.decline[id]`, `contracts.cancel[id]` |
| `LaunchDataLinkHandler` | `ksp.launch[ship, facility, site, crew]`, `ksp.recover`, `ksp.revertToLaunch`, `ksp.revertToEditor[vab\|sph]`, `ksp.toSpaceCenter`, `ksp.toTrackingStation`, `ksp.canRevert*` |
| `ActionGroupBindingsDataLinkHandler` | `f.ag.bindings` (which parts/modules/actions are bound to each AG) |
| `StrategiesDataLinkHandler` | `strategies.all`, `strategies.activate[id, factor]`, `strategies.deactivate[id]` |

## Design notes

**Contracts long ids as strings:** Contract IDs frequently exceed 2^53 and silently lose precision when serialised as JSON numbers. `contracts.*` rows emit `"id": "<digits>"` and the action handlers accept both string and number forms for back-compat. Contract parameter rows include the parameter's runtime type plus typed fields (`parameterType` / `minAltitude` / `maxAltitude` / `body` / `situation` / `partName`) so consumers can render real progress bars without name-string heuristics.

**Action handlers fire from any scene.** `ksp.launch` refuses outside SC/Editor; `ksp.revertToLaunch` refuses outside Flight; `tech.unlock` refuses unaffordably-priced nodes; etc. - internal state checks, not blanket scene gates.

**`ksp.launch` always builds a `VesselCrewManifest`** even for unmanned launches. Passing null NREs inside `setStartupNewVessel` and leaves Flight half-initialised (frozen HUD, sentinel values).

## Tech-tree enrichment

`tech.nodes` rows now include:

- `description` - parsed from the tech tree's underlying `RDNode` config and run through `Localizer.Format` so it matches what KSP shows in the R&D dialog.
- `parts` - one entry per `AvailablePart` assigned to the node, with `name` / `title` / `manufacturer` / `category` / `entryCost` / `purchased`. Built once per game-load by indexing `PartLoader.LoadedPartsList` by `TechRequired`.

`kc.facilityLevels` rows now include `currentLevelText` and `nextLevelText` (from `UpgradeableFacility.GetLevelText(int)`) so consumers can show KSP's multi-line upgrade dialog text without mirroring it locally.

## Strategies / Administration Building

A new `StrategiesDataLinkHandler` adds three keys: `strategies.all`, `strategies.activate[id, factor]`, `strategies.deactivate[id]`. The interesting bit is that all three work from any scene.

KSP's `Strategy.CanBeActivated` / `Activate` / `Deactivate` dereference `Administration.Instance`, a `MonoBehaviour` that's only alive while the Admin Building dialog is open. That makes the stock methods unusable from a remote dashboard when the player isn't in front of the dialog. The handler replicates each check and mutation against publicly-accessible state (`StrategySystem`, `GameVariables`, `ScenarioUpgradeableFacilities`, `Funding`, `Reputation`, `ResearchAndDevelopment`, `Planetarium`) so the same operations work from Space Center, Editor, Flight, or Tracking Station. Reflection is used only to write `Strategy.isActive` and `Strategy.dateActivated`; everything else is a public API call. Behaviour matches stock KSP 1.12.

The replica section is cleanly fenced inside the handler with header/footer comments so the boundary against stock behaviour is obvious to anyone reading the file.

### Currency-modifier effective costs

KSP's `{Funding, ResearchAndDevelopment, Reputation}.Add*` methods apply the mutation *before* firing `GameEvents.Modifiers.OnCurrencyModifierQuery`, so consumers can't adjust the deduction by listening - they have to pre-query the modifier separately. Without that step, dashboards showing the nominal cost of a launch / facility upgrade / tech purchase will be wrong whenever a strategy is active (e.g. Aggressive Negotiations advertises -1.5% on launches and R&D purchases, and -0.05% on facility construction).

A new `CurrencyModifiers` helper wraps the pre-query in a one-liner. Existing rows now include a sidecar field next to each cost:

| Existing field | New sidecar | Transaction reason |
|---|---|---|
| `kc.facilityLevels.upgradeFunds` | `upgradeFundsEffective` | `StructureConstruction` |
| `kc.savedShips.requiresFunds` | `requiresFundsEffective` | `VesselRollout` |
| `tech.nodes.scienceCost` | `scienceCostEffective` | `RnDTechResearch` |
| `tech.nodes.parts[].entryCost` | `entryCostEffective` | `RnDPartPurchase` |

`strategies.all` also includes `effectiveCostReputation` per strategy, which mirrors `Reputation.addReputation_granular`'s per-unit walk against `GameVariables.reputationSubtraction`. The rep curve makes losses near the cap cost meaningfully more than at zero - a 14.5-nominal cost can deduct ~27 at 976 rep, so the nominal figure on its own is misleading.

## Validation

Tested locally on KSP 1.12.x with a custom HTTP/WS dashboard, in a career save:

- **Tech tree:** `tech.nodes` listed every node + its unlocked state from the Space Center; `tech.unlock[experimentalRocketry]` deducted science and unlocked the node in the R&D UI on the next tick. Per-node `description` and `parts` matched the in-game R&D dialog content.
- **KSC:** `kc.facilityLevels` returned the expected building list with current/max upgrade levels and `currentLevelText` / `nextLevelText` matching the in-game upgrade dialog; `kc.upgradeFacility[LaunchPad]` deducted funds and started the upgrade animation. `kc.crewRoster` exposed the full kerbal roster including experience and current assignment fields.
- **Contracts:** `contracts.active` rows included `parameterType` plus the typed fields for the well-known parameter classes (altitude, body, situation, part). Long contract IDs round-tripped correctly as strings.
- **Launch:** `ksp.launch[Stayputnik X, VAB, LaunchPad, Jeb;Bill]` launched the saved craft with the named crew aboard. Refuses outside SC/Editor as designed.
- **Scene-transition battery:** ran the full sequence Flight → Space Center → Tracking Station → (refused-launch from TS) → Space Center → launch → recover → Tracking Station. All six `ksp.*` scene actions worked correctly.
- **Action groups:** `f.ag.bindings` returned one row per (action, group) pair on a vessel with multiple custom bindings.
- **Strategies:** `strategies.all` returned from the Space Center without the Admin dialog being open; the currently-active strategy showed `isActive: true / canDeactivate: true` and every other strategy was blocked by the stock 1-active-limit gate with the localised human-readable reason. Round-tripped deactivate + activate end-to-end (Aggressive Negotiations → off, Fundraising Campaign → on at factor 0.05); change was reflected immediately in both `strategies.all` and the in-game Admin Building dialog. Per-strategy `effectiveCostReputation` matched the post-curve deduction observed on real activation to within ~1 unit.
- **Currency-modifiers:** tested with multiple strategies and confirmed their modifiers are correctly applied into values marked `effective`.
- **No regression** in any existing Flight-scene key while these were queried.
