### PR TITLE
chore: broaden AfterBuild.sh portability

### DIFF
--- a/Telemachus/AfterBuild.sh
+++ b/Telemachus/AfterBuild.sh
@@ -10,7 +10,8 @@ authHeader=()
 if [ -n "${GITHUB_TOKEN:-}" ]; then
   authHeader=(-H "Authorization: token $GITHUB_TOKEN")
 fi
-houstonUrl="$(curl --silent "${authHeader[@]}" "https://api.github.com/repos/TeleIO/houston/releases/latest" | grep '"browser_download_url":' | cut -d : -f2,3 | cut -d \" -f2)"
+# Portable expansion of a possibly-empty array under `set -u` (works on older bash too).
+houstonUrl="$(curl --silent ${authHeader[@]+"${authHeader[@]}"} "https://api.github.com/repos/TeleIO/houston/releases/latest" | grep '"browser_download_url":' | cut -d : -f2,3 | cut -d \" -f2)"
 mkonUrl="https://github.com/TeleIO/mkon/archive/master.zip"
 
 echo "$ProjectDir"
@@ -29,9 +30,9 @@ cp "$TargetDir/websocket-sharp.dll" "$ProjectDir/../publish/GameData/Telemachus/
 
 cp "$ProjectDir/../TelemachusReborn.version" "$ProjectDir/../publish/GameData/Telemachus/"
 
-cp -ra "$ProjectDir/../Parts/."                         "$ProjectDir/../publish/GameData/Telemachus/Parts/"
-cp -ra "$ProjectDir/../WebPages/WebPages/src/."         "$ProjectDir/../publish/GameData/Telemachus/Plugins/PluginData/Telemachus/"
-cp -ra "$ProjectDir/../Licences/."                      "$ProjectDir/../publish/GameData/Telemachus/"
+cp -pR "$ProjectDir/../Parts/."                         "$ProjectDir/../publish/GameData/Telemachus/Parts/"
+cp -pR "$ProjectDir/../WebPages/WebPages/src/."         "$ProjectDir/../publish/GameData/Telemachus/Plugins/PluginData/Telemachus/"
+cp -pR "$ProjectDir/../Licences/."                      "$ProjectDir/../publish/GameData/Telemachus/"
 cp     "$ProjectDir/../README.md"                       "$ProjectDir/../publish/GameData/Telemachus/"
 
 # Download Houston
@@ -43,7 +44,7 @@ unzip Houston.zip -d "$ProjectDir/../publish/GameData/Telemachus/Plugins/PluginD
 curl -Lo mkon.zip "$mkonUrl"
 mkdir -p "$ProjectDir/../publish/GameData/Telemachus/Plugins/PluginData/Telemachus/mkon"
 unzip mkon.zip
-cp -ra mkon-master/. "$ProjectDir/../publish/GameData/Telemachus/Plugins/PluginData/Telemachus/mkon"
+cp -pR mkon-master/. "$ProjectDir/../publish/GameData/Telemachus/Plugins/PluginData/Telemachus/mkon"
 
 rm Houston.zip mkon.zip
 rm -rf mkon-master
@@ -67,8 +68,8 @@ kspDir="$ProjectDir/../ksp-telemachus-dev"
 if [ -d "$kspDir" ]; then
   rm -rf "$kspDir/GameData/Telemachus"
   mkdir -p "$kspDir/GameData/Telemachus/Plugins/PluginData/Telemachus/test"
-  cp -ra "$ProjectDir/../WebPages/WebPagesTest/src/." "$kspDir/GameData/Telemachus/Plugins/PluginData/Telemachus/test"
-  cp -ra "$ProjectDir/../publish/GameData/."          "$kspDir/GameData/"
+  cp -pR "$ProjectDir/../WebPages/WebPagesTest/src/." "$kspDir/GameData/Telemachus/Plugins/PluginData/Telemachus/test"
+  cp -pR "$ProjectDir/../publish/GameData/."          "$kspDir/GameData/"
 fi
 
 ls "$ProjectDir/../publish/GameData/Telemachus/Plugins/PluginData/Telemachus/"


### PR DESCRIPTION
⚠️ I've used Claude to make this change and draft most of the description below. Built, tested locally in KSP, and happy with the result, so sharing here.

## Summary

Two small tweaks to `Telemachus/AfterBuild.sh` so the post-build step runs cleanly under a wider range of bash versions and coreutils variants. Behaviour-preserving on the existing build path.

## Changes

1. **Possibly-empty array expansion under `set -u`** — `"${authHeader[@]}"` errors on older bash versions when the array is empty. `${authHeader[@]+"${authHeader[@]}"}` is the portable equivalent that expands to nothing in the empty case and works on both old and current bash. Same observable behaviour when `GITHUB_TOKEN` is set.

2. **`cp -pR` instead of `cp -ra`** — `-a` is a GNU shorthand for `-dR --preserve=all` that BSD `cp` doesn't accept in the combined short form. `cp -pR` is POSIX-compliant, preserves modes + timestamps (the bits the previous `-a` preserved that the build actually cares about), and works under both GNU and BSD coreutils. Recursive copy semantics are unchanged.

## Validation

Tested locally on macOS (bash 3.2 / BSD coreutils):

- `dotnet build -c Release` completes successfully; `publish/api-schema.json` is regenerated and contains the same entry shapes as before.
- The release-staged `publish/GameData/Telemachus/` tree contains the expected Parts, WebPages, Licences, Houston, and mkon contents with the same directory structure as a Linux build. File modes are preserved (verified with `stat`).
- With `GITHUB_TOKEN` set, the Houston download still uses the auth header (no observable change vs trunk).

Haven't re-run CI from scratch, but the existing CI is on Linux and the changes are no-ops there — the `${arr[@]+...}` form expands identically to `"${arr[@]}"` on bash 4+, and `cp -pR` matches `cp -ra`'s preservation semantics on GNU coreutils.
