### PR TITLE
feat: vessel parts API — topology + per-part resource / thermal / behavioural state

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,49 @@ Each entry in `parts[]`:
 
 </details>
 
+<details><summary>Part behavioural state</summary>
+
+Live deployable / activation state for a single part, keyed by `flightID`
+(same id `v.topology` emits). Intended for UI that reflects whether a panel
+is extended, an engine is firing, a parachute is armed, etc. — not for
+high-frequency telemetry.
+
+| Key | Description | Type |
+|-----|-------------|------|
+| `v.partState[flightId]` | `{ seq, modules: [...] }` — see below | object |
+
+The response carries a vessel-level `seq` that bumps whenever the cache is
+invalidated. Consumers can dedup unchanged pushes by comparing `seq` rather
+than walking the modules array.
+
+Each entry in `modules[]` has a `type` (semantic, not the raw KSP module
+name) and a `state` from the standard vocabulary. Type-specific extras
+(e.g. `tracking` on solar panels, `flameout` on engines) are included
+inline when present.
+
+Supported semantic types and their KSP-module sources:
+
+| `type` | Source module | State vocabulary used |
+|---|---|---|
+| `solarPanel` | `ModuleDeployableSolarPanel` | extended / retracted / deploying / retracting / broken — plus `tracking: bool` |
+| `radiator` | `ModuleDeployableRadiator` | extended / retracted / deploying / retracting / broken |
+| `antenna` | `ModuleDeployableAntenna` | extended / retracted / deploying / retracting / broken |
+| `parachute` | `ModuleParachute` | stowed / armed / deploying / extended / broken |
+| `engine` | `ModuleEngines` (incl. `ModuleEnginesFX`) | active / inactive — plus `flameout: true` when out of fuel |
+| `drill` | `ModuleResourceHarvester` | active / inactive |
+| `cargoBay` | `ModuleCargoBay` (paired with `ModuleAnimateGeneric`) | extended / retracted / deploying / retracting |
+| `landingGear` | `ModuleWheels.ModuleWheelDeployment` | extended / retracted / deploying / retracting / broken |
+
+Invalidation hooks: `onStageActivate`, `onVesselWasModified`, `onPartCouple`,
+`onPartUndock`, `onPartDie`, `onPartActionUIDismiss`. A 10s backstop covers
+player interactions that don't fire a global event (right-click → Extend
+Solar Panel, the G key for landing gear, custom action groups). Worst-case
+staleness is therefore ~10 seconds for non-event-triggered transitions —
+mid-animation transitions like "deploying → extended" may also lag up to
+that bound if no other event fires in the interim.
+
+</details>
+
 ### `o.*` — Orbit
 
 <details><summary>Keplerian elements & apsides</summary>

--- a/README.md
+++ b/README.md
@@ -344,6 +344,41 @@ A machine-readable [OpenAPI 3.1 spec](docs/openapi.yaml) is auto-generated from 
 
 </details>
 
+<details><summary>Vessel topology</summary>
+
+Structural snapshot of the active vessel — parts, parent links, modules, and
+assembled-space positions. Cached and event-invalidated, so `v.topology` only
+recomputes when staging / docking / decoupling / part-death events fire.
+Subscribe to `v.topologySeq` and refetch `v.topology` when the seq changes
+rather than streaming the topology key directly.
+
+| Key | Description | Type |
+|-----|-------------|------|
+| `v.topologySeq` | Monotonic counter — bumps on every vessel structural change | int |
+| `v.topology` | `{ topologySeq, rootFlightId, parts: [...] }` (see below) | object |
+
+Each entry in `parts[]`:
+
+| Field | Description |
+|-------|-------------|
+| `flightId` | Stable runtime id within a flight — use for live-lookup keys (`r.resourceFor`, `therm.part`) |
+| `persistentId` | Cross-flight id (survives save/load) |
+| `parentFlightId` | `flightId` of the parent part, or `null` for the root |
+| `name` | Internal part name (e.g. `liquidEngine2`) |
+| `title` | Display name (e.g. "LV-T45 'Swivel' Liquid Fuel Engine") |
+| `manufacturer` | Display manufacturer |
+| `category` | `PartCategories` enum as string |
+| `inverseStage` | Stage at which this part separates |
+| `crewCapacity` | Max crew |
+| `maxTemp` | Internal thermal limit (K) |
+| `crashTolerance` | Impact tolerance |
+| `dryMass` | `Part.mass` |
+| `orgPos` | `[x, y, z]` — vessel-local, as-assembled |
+| `bounds.size` | `{ x, y, z }` — prefab renderer bounds in metres |
+| `modules` | Raw `PartModule.moduleName` strings (passthrough, no filtering) |
+
+</details>
+
 ### `o.*` — Orbit
 
 <details><summary>Keplerian elements & apsides</summary>
@@ -680,8 +715,9 @@ All body queries take a body index parameter: `b.name[0]` (Kerbol), `b.name[1]` 
 | `r.resourceCurrent[name]` | Resource amount in current stage |
 | `r.resourceCurrentMax[name]` | Resource max in current stage |
 | `r.resourceNameList` | List of all resource names |
+| `r.resourceFor[flightId]` | Live resources for a single part — `{ resourceName: { amount, maxAmount }, … }`; empty object if the flightId isn't found |
 
-Example: `r.resource[ElectricCharge]`, `r.resource[LiquidFuel]`, `r.resource[Oxidizer]`
+Example: `r.resource[ElectricCharge]`, `r.resource[LiquidFuel]`, `r.resource[Oxidizer]`, `r.resourceFor[12345]`
 
 ### `s.*` — Sensors
 
@@ -1020,6 +1056,7 @@ Each burn object contains `{ tangent, normal, binormal, initial_time, duration }
 | `therm.heatShieldTemp` | Heat shield temperature | K |
 | `therm.heatShieldTempCelsius` | Heat shield temperature | C |
 | `therm.heatShieldFlux` | Heat shield thermal flux | kW |
+| `therm.part[flightId]` | Per-part thermal state — `{ temperature, maxTemperature, temperatureK, maxTemperatureK }`; `null` if the flightId isn't found. Core part temperature only — skin temp not exposed | object |
 
 ### `sci.*` / `career.*` / `comm.*` — Science, career & comms *(WIP — in testing)*
 

--- a/README.md
+++ b/README.md
@@ -375,6 +375,9 @@ Each entry in `parts[]`:
 | `dryMass` | `Part.mass` |
 | `orgPos` | `[x, y, z]` — vessel-local, as-assembled |
 | `bounds.size` | `{ x, y, z }` — prefab renderer bounds in metres |
+| `bounds.center` | `{ x, y, z }` — prefab renderer bounds centre offset in metres |
+| `up` | `[x, y, z]` — part-local up vector in assembled-space orientation |
+| `fuelLineTarget` | `flightId` of the fuel line's destination part; `null` for non-fuel-line parts |
 | `modules` | Raw `PartModule.moduleName` strings (passthrough, no filtering) |
 
 </details>

--- a/Telemachus/AfterBuild.sh
+++ b/Telemachus/AfterBuild.sh
@@ -57,6 +57,7 @@ if [ -n "$schemaFile" ]; then
     | grep -v 'SCHEMA_JSON' \
     | sed 's/.*internal const string Json = @"//;s/";//' \
     | sed 's/""/"/g' \
+    | sed "s|${ProjectDir%/}/||g" \
     > "$ProjectDir/../publish/api-schema.json"
   echo "Extracted API schema to publish/api-schema.json"
 else

--- a/Telemachus/src/KSPAPIBase.cs
+++ b/Telemachus/src/KSPAPIBase.cs
@@ -24,6 +24,7 @@ namespace Telemachus
             APIHandlers.Add(new LandingDataLinkHandler(formatters));
             APIHandlers.Add(new ThermalDataLinkHandler(formatters));
             APIHandlers.Add(new PartsTopologyDataLinkHandler(formatters));
+            APIHandlers.Add(new PartStateDataLinkHandler(formatters));
             APIHandlers.Add(new ScienceCareerDataLinkHandler(formatters));
             APIHandlers.Add(new TimeWarpDataLinkHandler(formatters));
             APIHandlers.Add(new TargetDataLinkHandler(formatters));

--- a/Telemachus/src/KSPAPIBase.cs
+++ b/Telemachus/src/KSPAPIBase.cs
@@ -23,6 +23,7 @@ namespace Telemachus
             APIHandlers.Add(new KerbalismDataLinkHandler(formatters));
             APIHandlers.Add(new LandingDataLinkHandler(formatters));
             APIHandlers.Add(new ThermalDataLinkHandler(formatters));
+            APIHandlers.Add(new PartsTopologyDataLinkHandler(formatters));
             APIHandlers.Add(new ScienceCareerDataLinkHandler(formatters));
             APIHandlers.Add(new TimeWarpDataLinkHandler(formatters));
             APIHandlers.Add(new TargetDataLinkHandler(formatters));

--- a/Telemachus/src/PartStateDataLinkHandler.cs
+++ b/Telemachus/src/PartStateDataLinkHandler.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Collections.Generic;
+using ModuleWheels;
+
+namespace Telemachus
+{
+    /// <summary>
+    /// Live runtime behavioural state for an individual part — deployable /
+    /// activation state per supported module (solar panels, radiators,
+    /// parachutes, engines, drills, cargo bays, landing gear). Cached and
+    /// event-invalidated; intended for "is the panel deployed?" style UI,
+    /// not high-frequency telemetry.
+    /// </summary>
+    public class PartStateDataLinkHandler : DataLinkHandler
+    {
+        // Vessel-level invalidation counter — stamped into every per-part
+        // response so consumers can dedup unchanged pushes without doing
+        // a deep compare on the modules array.
+        private static int _seq;
+
+        // Per-flightID payload cache. Built lazily on read after the cache
+        // is cleared by an invalidation event or the backstop timer.
+        private static readonly Dictionary<uint, Dictionary<string, object>> _cache
+            = new Dictionary<uint, Dictionary<string, object>>();
+
+        // Backstop: 10s after the last invalidation, force a re-walk. Covers
+        // PAW interactions that don't fire a global GameEvent (right-click
+        // → Extend Solar Panel) — the cache catches up within 10s without
+        // us hooking per-module callbacks.
+        private static DateTime _lastInvalidatedAt = DateTime.UtcNow;
+        private static readonly TimeSpan BACKSTOP_INTERVAL = TimeSpan.FromSeconds(10);
+
+        public PartStateDataLinkHandler(FormatterProvider formatters)
+            : base(formatters)
+        {
+            // No global onActionGroup* in this KSP — toggles like G (gear)
+            // or U (lights) play their animations without firing a generic
+            // event we can hook. AG-driven deploys fall back on the 10s
+            // backstop, which keeps the staleness bounded.
+            GameEvents.onStageActivate.Add(OnStageActivate);
+            GameEvents.onVesselWasModified.Add(OnVesselChanged);
+            GameEvents.onPartCouple.Add(OnPartCouple);
+            GameEvents.onPartUndock.Add(OnPartChanged);
+            GameEvents.onPartDie.Add(OnPartChanged);
+            GameEvents.onPartActionUIDismiss.Add(OnPartActionUIDismiss);
+        }
+
+        // --- Invalidation ---
+
+        private static void Invalidate()
+        {
+            _seq++;
+            _cache.Clear();
+            _lastInvalidatedAt = DateTime.UtcNow;
+        }
+
+        private void OnStageActivate(int stage) => Invalidate();
+        private void OnVesselChanged(Vessel v) => Invalidate();
+        private void OnPartChanged(Part p) => Invalidate();
+        private void OnPartCouple(GameEvents.FromToAction<Part, Part> data) => Invalidate();
+        private void OnPartActionUIDismiss(Part p) => Invalidate();
+
+        // --- Endpoint ---
+
+        [TelemetryAPI("v.partState",
+            "Live deployable / behavioural state for a single part keyed by " +
+            "flightID. Returns { seq, modules: [{ type, state, ...extras }] }. " +
+            "Cached server-side and invalidated on staging, action-group " +
+            "events, vessel modifications, part death / undock / couple, and " +
+            "PAW dismiss; plus a 10s backstop covering player right-click " +
+            "interactions that don't fire a global event. Consumers subscribe " +
+            "and dedup on the seq field rather than re-processing the modules " +
+            "array on every push.",
+            AlwaysEvaluable = false,
+            Plotable = false,
+            Category = "vessel",
+            ReturnType = "object",
+            Params = "uint flightId")]
+        object PartState(DataSources ds)
+        {
+            // Backstop check on every read — cheaper than scheduling a timer.
+            if (DateTime.UtcNow - _lastInvalidatedAt > BACKSTOP_INTERVAL)
+            {
+                Invalidate();
+            }
+
+            if (ds.args == null || ds.args.Count == 0) return null;
+            if (!uint.TryParse(ds.args[0], out var flightId)) return null;
+            if (ds.vessel == null || ds.vessel.parts == null) return null;
+
+            if (_cache.TryGetValue(flightId, out var cached)) return cached;
+
+            foreach (var part in ds.vessel.parts)
+            {
+                if (part == null || part.flightID != flightId) continue;
+                var result = BuildPartState(part);
+                _cache[flightId] = result;
+                return result;
+            }
+            return null;
+        }
+
+        // --- Build ---
+
+        private static Dictionary<string, object> BuildPartState(Part part)
+        {
+            var modules = new List<Dictionary<string, object>>();
+            if (part.Modules != null)
+            {
+                foreach (var module in part.Modules)
+                {
+                    if (module == null) continue;
+                    var entry = SerialiseModule(module, part);
+                    if (entry != null) modules.Add(entry);
+                }
+            }
+            return new Dictionary<string, object>
+            {
+                ["seq"] = _seq,
+                ["modules"] = modules,
+            };
+        }
+
+        private static Dictionary<string, object> SerialiseModule(PartModule module, Part part)
+        {
+            switch (module)
+            {
+                case ModuleDeployableSolarPanel solar:
+                    return new Dictionary<string, object>
+                    {
+                        ["type"] = "solarPanel",
+                        ["state"] = MapDeployState(solar.deployState),
+                        ["tracking"] = solar.isTracking,
+                    };
+
+                case ModuleDeployableRadiator radiator:
+                    return new Dictionary<string, object>
+                    {
+                        ["type"] = "radiator",
+                        ["state"] = MapDeployState(radiator.deployState),
+                    };
+
+                case ModuleDeployableAntenna antenna:
+                    return new Dictionary<string, object>
+                    {
+                        ["type"] = "antenna",
+                        ["state"] = MapDeployState(antenna.deployState),
+                    };
+
+                case ModuleParachute parachute:
+                    return new Dictionary<string, object>
+                    {
+                        ["type"] = "parachute",
+                        ["state"] = MapParachuteState(parachute.deploymentState),
+                    };
+
+                case ModuleEngines engine:
+                    // ModuleEnginesFX inherits ModuleEngines so this case
+                    // catches both.
+                    var engineEntry = new Dictionary<string, object>
+                    {
+                        ["type"] = "engine",
+                        ["state"] = engine.EngineIgnited ? "active" : "inactive",
+                    };
+                    if (engine.flameout) engineEntry["flameout"] = true;
+                    return engineEntry;
+
+                case ModuleResourceHarvester harvester:
+                    return new Dictionary<string, object>
+                    {
+                        ["type"] = "drill",
+                        ["state"] = harvester.IsActivated ? "active" : "inactive",
+                    };
+
+                case ModuleCargoBay cargoBay:
+                    return SerialiseCargoBay(cargoBay, part);
+
+                case ModuleWheelDeployment wheel:
+                    return new Dictionary<string, object>
+                    {
+                        ["type"] = "landingGear",
+                        ["state"] = MapWheelState(wheel.stateString),
+                    };
+
+                default:
+                    // Not a behavioural module the API surfaces — skip.
+                    return null;
+            }
+        }
+
+        // --- Mappings ---
+
+        // Order standardised in the design doc:
+        // extended / retracted / deploying / retracting / stowed / armed /
+        // active / inactive / broken / unknown.
+
+        private static string MapDeployState(ModuleDeployablePart.DeployState state)
+        {
+            switch (state)
+            {
+                case ModuleDeployablePart.DeployState.EXTENDED: return "extended";
+                case ModuleDeployablePart.DeployState.RETRACTED: return "retracted";
+                case ModuleDeployablePart.DeployState.EXTENDING: return "deploying";
+                case ModuleDeployablePart.DeployState.RETRACTING: return "retracting";
+                case ModuleDeployablePart.DeployState.BROKEN: return "broken";
+                default: return "unknown";
+            }
+        }
+
+        private static string MapParachuteState(ModuleParachute.deploymentStates state)
+        {
+            switch (state)
+            {
+                case ModuleParachute.deploymentStates.STOWED: return "stowed";
+                case ModuleParachute.deploymentStates.ACTIVE: return "armed";
+                case ModuleParachute.deploymentStates.SEMIDEPLOYED: return "deploying";
+                case ModuleParachute.deploymentStates.DEPLOYED: return "extended";
+                case ModuleParachute.deploymentStates.CUT: return "broken";
+                default: return "unknown";
+            }
+        }
+
+        // Stock cargo bays carry a paired ModuleAnimateGeneric on the same
+        // part; animTime is 0 (closed) → 1 (open). animSpeed sign tells us
+        // direction during animation. ModuleCargoBay's own deployModule ref
+        // is private so we reach for the sibling module instead.
+        private static Dictionary<string, object> SerialiseCargoBay(ModuleCargoBay bay, Part part)
+        {
+            ModuleAnimateGeneric anim = null;
+            if (part.Modules != null)
+            {
+                foreach (var m in part.Modules)
+                {
+                    if (m is ModuleAnimateGeneric mag) { anim = mag; break; }
+                }
+            }
+
+            string state;
+            if (anim == null)
+            {
+                state = "unknown";
+            }
+            else if (anim.animTime >= 0.95f)
+            {
+                state = "extended";
+            }
+            else if (anim.animTime <= 0.05f)
+            {
+                state = "retracted";
+            }
+            else
+            {
+                // Mid-animation. Speed sign distinguishes opening vs closing;
+                // animSpeed > 0 = playing forward = opening.
+                state = anim.animSpeed >= 0f ? "deploying" : "retracting";
+            }
+
+            return new Dictionary<string, object>
+            {
+                ["type"] = "cargoBay",
+                ["state"] = state,
+            };
+        }
+
+        // ModuleWheelDeployment uses a KerbalFSM whose state names are
+        // "Deployed" / "Retracted" / "Deploying" / "Retracting" / variants.
+        // Normalise to the design vocabulary.
+        private static string MapWheelState(string stateString)
+        {
+            if (string.IsNullOrEmpty(stateString)) return "unknown";
+            var s = stateString.ToLowerInvariant();
+            if (s.Contains("deployed")) return "extended";
+            if (s.Contains("retracted")) return "retracted";
+            if (s.Contains("deploying")) return "deploying";
+            if (s.Contains("retracting")) return "retracting";
+            if (s.Contains("broken")) return "broken";
+            return s;
+        }
+    }
+}

--- a/Telemachus/src/PartStateDataLinkHandler.cs
+++ b/Telemachus/src/PartStateDataLinkHandler.cs
@@ -274,7 +274,7 @@ namespace Telemachus
             if (s.Contains("deploying")) return "deploying";
             if (s.Contains("retracting")) return "retracting";
             if (s.Contains("broken")) return "broken";
-            return s;
+            return "unknown";
         }
     }
 }

--- a/Telemachus/src/PartsTopologyDataLinkHandler.cs
+++ b/Telemachus/src/PartsTopologyDataLinkHandler.cs
@@ -18,7 +18,16 @@ namespace Telemachus
         private static Dictionary<string, object> _cached;
 
         // Prefab bounds are immutable for a session — cache by AvailablePart.name.
-        private static readonly Dictionary<string, Vector3> _prefabSizeCache = new();
+        // Cached as a Vector3 pair (size, center). center is in part-local frame
+        // relative to part.transform — non-zero for parts whose mesh does not
+        // sit at the attach-node anchor (radial decouplers, surface-mounted
+        // ladders, anything whose pivot is offset from its visual centroid).
+        private struct PrefabBounds
+        {
+            public Vector3 size;
+            public Vector3 center;
+        }
+        private static readonly Dictionary<string, PrefabBounds> _prefabBoundsCache = new();
 
         public PartsTopologyDataLinkHandler(FormatterProvider formatters)
             : base(formatters)
@@ -72,7 +81,10 @@ namespace Telemachus
             "receiving tank for fuel-line parts, null otherwise), name, " +
             "title, manufacturer, category, inverseStage, crewCapacity, " +
             "maxTemp, crashTolerance, dryMass, orgPos[x,y,z], up[x,y,z] " +
-            "(part-local up in vessel frame), bounds.size{x,y,z}, modules[]. " +
+            "(part-local up in vessel frame), bounds.size{x,y,z}, " +
+            "bounds.center{x,y,z} (mesh-center offset from orgPos in " +
+            "vessel-local frame — already rotated by orgRot; add it to " +
+            "orgPos to get the mesh centre in assembly space), modules[]. " +
             "Cached and event-invalidated — subscribe to v.topologySeq to " +
             "detect changes rather than streaming this key.",
             AlwaysEvaluable = false,
@@ -133,7 +145,8 @@ namespace Telemachus
         {
             var info = part.partInfo;
             var orgPos = part.orgPos;
-            var size = GetPrefabSize(info);
+            var prefab = GetPrefabBounds(info);
+            var size = prefab.size;
             // Part's "up" axis in vessel-local frame — orgRot is the
             // as-assembled rotation relative to the vessel root, so this
             // captures whether a part was mounted axially (up ≈ +Y),
@@ -141,6 +154,15 @@ namespace Telemachus
             // this to orient nose cones, decouplers, docking ports etc.
             // without inferring orientation from neighbour geometry.
             var up = part.orgRot * Vector3.up;
+            // Mesh-center offset, rotated into vessel-local frame. orgPos
+            // is the attach-node anchor — for radial-mount parts (radial
+            // decouplers, surface ladders, brackets) the mesh sits off-
+            // anchor and a renderer that centred the body box on orgPos
+            // produced visibly-sunken parts. Emitting the rotated offset
+            // saves the client from needing the full orgRot quaternion
+            // just to position the box correctly. Add this to orgPos to
+            // get the mesh centre in vessel-local frame.
+            var boundsCenterOffset = part.orgRot * prefab.center;
 
             var modules = new List<string>();
             object fuelLineTarget = null;
@@ -198,6 +220,12 @@ namespace Telemachus
                         ["y"] = size.y,
                         ["z"] = size.z,
                     },
+                    ["center"] = new Dictionary<string, object>
+                    {
+                        ["x"] = boundsCenterOffset.x,
+                        ["y"] = boundsCenterOffset.y,
+                        ["z"] = boundsCenterOffset.z,
+                    },
                 },
 
                 ["modules"] = modules,
@@ -207,29 +235,37 @@ namespace Telemachus
         // Prefab bounds are stable across the session — cache per AvailablePart
         // by name. Live render bounds would inflate with vessel rotation and
         // jitter as joints flex; the prefab is the "as designed" silhouette.
-        private static Vector3 GetPrefabSize(AvailablePart info)
+        // We track both size *and* center: for parts whose mesh isn't centred
+        // on the attach-node anchor (radial decouplers, surface ladders,
+        // structural brackets), `center` is the offset in part-local frame
+        // and the client must apply it to position the body box correctly.
+        private static PrefabBounds GetPrefabBounds(AvailablePart info)
         {
-            if (info == null || info.partPrefab == null) return Vector3.zero;
+            if (info == null || info.partPrefab == null)
+            {
+                return new PrefabBounds { size = Vector3.zero, center = Vector3.zero };
+            }
 
             var key = info.name ?? string.Empty;
-            if (_prefabSizeCache.TryGetValue(key, out var cached)) return cached;
+            if (_prefabBoundsCache.TryGetValue(key, out var cached)) return cached;
 
-            Vector3 size;
+            var result = new PrefabBounds { size = Vector3.zero, center = Vector3.zero };
             try
             {
                 var prefab = info.partPrefab;
                 var bounds = PartGeometryUtil.MergeBounds(
                     PartGeometryUtil.GetPartRendererBounds(prefab),
                     prefab.transform);
-                size = bounds.size;
+                result.size = bounds.size;
+                result.center = bounds.center;
             }
             catch (Exception)
             {
-                size = Vector3.zero;
+                // Leave both at zero.
             }
 
-            _prefabSizeCache[key] = size;
-            return size;
+            _prefabBoundsCache[key] = result;
+            return result;
         }
     }
 }

--- a/Telemachus/src/PartsTopologyDataLinkHandler.cs
+++ b/Telemachus/src/PartsTopologyDataLinkHandler.cs
@@ -23,6 +23,7 @@ namespace Telemachus
             : base(formatters)
         {
             GameEvents.onVesselWasModified.Add(OnVesselChanged);
+            GameEvents.onVesselChange.Add(OnVesselChanged);
             GameEvents.onPartCouple.Add(OnPartCouple);
             GameEvents.onPartUndock.Add(OnPartChanged);
             GameEvents.onPartDie.Add(OnPartChanged);

--- a/Telemachus/src/PartsTopologyDataLinkHandler.cs
+++ b/Telemachus/src/PartsTopologyDataLinkHandler.cs
@@ -22,7 +22,16 @@ namespace Telemachus
         public PartsTopologyDataLinkHandler(FormatterProvider formatters)
             : base(formatters)
         {
-            GameEvents.onVesselWasModified.Add(OnVesselChanged);
+            // Subscribe only to events that actually change topology output.
+            // The payload is built from prefab bounds (cached per AvailablePart),
+            // the as-assembled orgPos, parent links, and the static module
+            // name list — none of which change with deployable state, engine
+            // ignition, parachute arming, crew transfer, or any other
+            // non-structural change. onVesselWasModified fires on every such
+            // change and was previously subscribed, causing topology seq to
+            // bump dozens of times per flight without the payload changing.
+            // Limiting the subscriptions to the genuinely-structural events
+            // below keeps seq bumps load-bearing.
             GameEvents.onVesselChange.Add(OnVesselChanged);
             GameEvents.onPartCouple.Add(OnPartCouple);
             GameEvents.onPartUndock.Add(OnPartChanged);

--- a/Telemachus/src/PartsTopologyDataLinkHandler.cs
+++ b/Telemachus/src/PartsTopologyDataLinkHandler.cs
@@ -69,7 +69,8 @@ namespace Telemachus
             "Active vessel topology: rootFlightId + per-part flightId, " +
             "persistentId, parentFlightId, name, title, manufacturer, " +
             "category, inverseStage, crewCapacity, maxTemp, crashTolerance, " +
-            "dryMass, orgPos[x,y,z], bounds.size{x,y,z}, modules[]. " +
+            "dryMass, orgPos[x,y,z], up[x,y,z] (part-local up in vessel " +
+            "frame), bounds.size{x,y,z}, modules[]. " +
             "Cached and event-invalidated — subscribe to v.topologySeq to " +
             "detect changes rather than streaming this key.",
             AlwaysEvaluable = false,
@@ -131,6 +132,13 @@ namespace Telemachus
             var info = part.partInfo;
             var orgPos = part.orgPos;
             var size = GetPrefabSize(info);
+            // Part's "up" axis in vessel-local frame — orgRot is the
+            // as-assembled rotation relative to the vessel root, so this
+            // captures whether a part was mounted axially (up ≈ +Y),
+            // radially (up along ±X / ±Z), or inverted. Ship Map uses
+            // this to orient nose cones, decouplers, docking ports etc.
+            // without inferring orientation from neighbour geometry.
+            var up = part.orgRot * Vector3.up;
 
             var modules = new List<string>();
             if (part.Modules != null)
@@ -166,6 +174,7 @@ namespace Telemachus
                 ["dryMass"] = part.mass,
 
                 ["orgPos"] = new object[] { orgPos.x, orgPos.y, orgPos.z },
+                ["up"] = new object[] { up.x, up.y, up.z },
 
                 ["bounds"] = new Dictionary<string, object>
                 {

--- a/Telemachus/src/PartsTopologyDataLinkHandler.cs
+++ b/Telemachus/src/PartsTopologyDataLinkHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using CompoundParts;
 using UnityEngine;
 
 namespace Telemachus
@@ -67,10 +68,11 @@ namespace Telemachus
 
         [TelemetryAPI("v.topology",
             "Active vessel topology: rootFlightId + per-part flightId, " +
-            "persistentId, parentFlightId, name, title, manufacturer, " +
-            "category, inverseStage, crewCapacity, maxTemp, crashTolerance, " +
-            "dryMass, orgPos[x,y,z], up[x,y,z] (part-local up in vessel " +
-            "frame), bounds.size{x,y,z}, modules[]. " +
+            "persistentId, parentFlightId, fuelLineTarget (flightId of the " +
+            "receiving tank for fuel-line parts, null otherwise), name, " +
+            "title, manufacturer, category, inverseStage, crewCapacity, " +
+            "maxTemp, crashTolerance, dryMass, orgPos[x,y,z], up[x,y,z] " +
+            "(part-local up in vessel frame), bounds.size{x,y,z}, modules[]. " +
             "Cached and event-invalidated — subscribe to v.topologySeq to " +
             "detect changes rather than streaming this key.",
             AlwaysEvaluable = false,
@@ -141,12 +143,23 @@ namespace Telemachus
             var up = part.orgRot * Vector3.up;
 
             var modules = new List<string>();
+            object fuelLineTarget = null;
             if (part.Modules != null)
             {
                 foreach (var module in part.Modules)
                 {
                     if (module == null) continue;
                     modules.Add(module.moduleName ?? string.Empty);
+                    // CModuleFuelLine.target (inherited from CompoundPartModule)
+                    // points at the "to" tank — the receiving end of the line.
+                    // The "from" end is already discoverable via parentFlightId.
+                    // Resolving here keeps the wire format flat and avoids the
+                    // client walking modules to fish out the linkage.
+                    if (fuelLineTarget == null && module is CModuleFuelLine line
+                        && line.target != null)
+                    {
+                        fuelLineTarget = line.target.flightID;
+                    }
                 }
             }
 
@@ -157,6 +170,7 @@ namespace Telemachus
                 ["parentFlightId"] = part.parent != null
                     ? (object)part.parent.flightID
                     : null,
+                ["fuelLineTarget"] = fuelLineTarget,
 
                 ["name"] = info != null ? info.name ?? string.Empty : string.Empty,
                 ["title"] = info != null ? info.title ?? string.Empty : string.Empty,

--- a/Telemachus/src/PartsTopologyDataLinkHandler.cs
+++ b/Telemachus/src/PartsTopologyDataLinkHandler.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Telemachus
+{
+    /// <summary>
+    /// Vessel topology snapshot — assembled-space part graph for the active
+    /// vessel. Cached and event-invalidated, not recomputed per tick. Lookup
+    /// keys (r.resourceFor, therm.part) ride on flightID emitted here.
+    /// </summary>
+    public class PartsTopologyDataLinkHandler : DataLinkHandler
+    {
+        private static int _topologySeq;
+        private static Vessel _cachedVessel;
+        private static int _cachedFor;
+        private static Dictionary<string, object> _cached;
+
+        // Prefab bounds are immutable for a session — cache by AvailablePart.name.
+        private static readonly Dictionary<string, Vector3> _prefabSizeCache = new();
+
+        public PartsTopologyDataLinkHandler(FormatterProvider formatters)
+            : base(formatters)
+        {
+            GameEvents.onVesselWasModified.Add(OnVesselChanged);
+            GameEvents.onPartCouple.Add(OnPartCouple);
+            GameEvents.onPartUndock.Add(OnPartChanged);
+            GameEvents.onPartDie.Add(OnPartChanged);
+            GameEvents.onVesselCreate.Add(OnVesselChanged);
+            GameEvents.onVesselDestroy.Add(OnVesselChanged);
+            GameEvents.onFlightReady.Add(OnFlightReady);
+        }
+
+        // --- Event handlers: bump the seq, drop the cache, rebuild lazily. ---
+
+        private static void Invalidate()
+        {
+            _topologySeq++;
+            _cached = null;
+            _cachedVessel = null;
+        }
+
+        private void OnVesselChanged(Vessel v) => Invalidate();
+        private void OnPartChanged(Part p) => Invalidate();
+        private void OnPartCouple(GameEvents.FromToAction<Part, Part> data) => Invalidate();
+        private void OnFlightReady() => Invalidate();
+
+        // --- Endpoints ---
+
+        [TelemetryAPI("v.topologySeq",
+            "Monotonic counter bumped whenever vessel topology changes. " +
+            "Subscribe to this and refetch v.topology only when it ticks.",
+            AlwaysEvaluable = true,
+            Category = "vessel",
+            ReturnType = "int")]
+        object TopologySeq(DataSources ds) => _topologySeq;
+
+        [TelemetryAPI("v.topology",
+            "Active vessel topology: rootFlightId + per-part flightId, " +
+            "persistentId, parentFlightId, name, title, manufacturer, " +
+            "category, inverseStage, crewCapacity, maxTemp, crashTolerance, " +
+            "dryMass, orgPos[x,y,z], bounds.size{x,y,z}, modules[]. " +
+            "Cached and event-invalidated — subscribe to v.topologySeq to " +
+            "detect changes rather than streaming this key.",
+            AlwaysEvaluable = false,
+            Plotable = false,
+            Category = "vessel",
+            ReturnType = "object")]
+        object Topology(DataSources ds)
+        {
+            var vessel = ds.vessel;
+            if (vessel == null) return null;
+
+            // Cache by (vessel, seq) — a swap of ActiveVessel without an
+            // event fire still needs a fresh build.
+            if (_cached != null && ReferenceEquals(_cachedVessel, vessel)
+                && _cachedFor == _topologySeq)
+                return _cached;
+
+            _cached = BuildTopology(vessel);
+            _cachedVessel = vessel;
+            _cachedFor = _topologySeq;
+            return _cached;
+        }
+
+        // --- Builder ---
+
+        private static Dictionary<string, object> BuildTopology(Vessel vessel)
+        {
+            var parts = new List<Dictionary<string, object>>();
+            var rootFlightId = 0u;
+
+            if (vessel.parts == null)
+            {
+                return new Dictionary<string, object>
+                {
+                    ["topologySeq"] = _topologySeq,
+                    ["rootFlightId"] = 0u,
+                    ["parts"] = parts,
+                };
+            }
+
+            if (vessel.rootPart != null) rootFlightId = vessel.rootPart.flightID;
+
+            foreach (var part in vessel.parts)
+            {
+                if (part == null) continue;
+                parts.Add(SerialisePart(part));
+            }
+
+            return new Dictionary<string, object>
+            {
+                ["topologySeq"] = _topologySeq,
+                ["rootFlightId"] = rootFlightId,
+                ["parts"] = parts,
+            };
+        }
+
+        private static Dictionary<string, object> SerialisePart(Part part)
+        {
+            var info = part.partInfo;
+            var orgPos = part.orgPos;
+            var size = GetPrefabSize(info);
+
+            var modules = new List<string>();
+            if (part.Modules != null)
+            {
+                foreach (var module in part.Modules)
+                {
+                    if (module == null) continue;
+                    modules.Add(module.moduleName ?? string.Empty);
+                }
+            }
+
+            return new Dictionary<string, object>
+            {
+                ["flightId"] = part.flightID,
+                ["persistentId"] = part.persistentId,
+                ["parentFlightId"] = part.parent != null
+                    ? (object)part.parent.flightID
+                    : null,
+
+                ["name"] = info != null ? info.name ?? string.Empty : string.Empty,
+                ["title"] = info != null ? info.title ?? string.Empty : string.Empty,
+                ["manufacturer"] = info != null
+                    ? info.manufacturer ?? string.Empty
+                    : string.Empty,
+                ["category"] = info != null ? info.category.ToString() : string.Empty,
+
+                ["inverseStage"] = part.inverseStage,
+
+                ["crewCapacity"] = part.CrewCapacity,
+                ["maxTemp"] = part.maxTemp,
+                ["crashTolerance"] = part.crashTolerance,
+
+                ["dryMass"] = part.mass,
+
+                ["orgPos"] = new object[] { orgPos.x, orgPos.y, orgPos.z },
+
+                ["bounds"] = new Dictionary<string, object>
+                {
+                    ["size"] = new Dictionary<string, object>
+                    {
+                        ["x"] = size.x,
+                        ["y"] = size.y,
+                        ["z"] = size.z,
+                    },
+                },
+
+                ["modules"] = modules,
+            };
+        }
+
+        // Prefab bounds are stable across the session — cache per AvailablePart
+        // by name. Live render bounds would inflate with vessel rotation and
+        // jitter as joints flex; the prefab is the "as designed" silhouette.
+        private static Vector3 GetPrefabSize(AvailablePart info)
+        {
+            if (info == null || info.partPrefab == null) return Vector3.zero;
+
+            var key = info.name ?? string.Empty;
+            if (_prefabSizeCache.TryGetValue(key, out var cached)) return cached;
+
+            Vector3 size;
+            try
+            {
+                var prefab = info.partPrefab;
+                var bounds = PartGeometryUtil.MergeBounds(
+                    PartGeometryUtil.GetPartRendererBounds(prefab),
+                    prefab.transform);
+                size = bounds.size;
+            }
+            catch (Exception)
+            {
+                size = Vector3.zero;
+            }
+
+            _prefabSizeCache[key] = size;
+            return size;
+        }
+    }
+}

--- a/Telemachus/src/ResourceHandlers.cs
+++ b/Telemachus/src/ResourceHandlers.cs
@@ -80,35 +80,210 @@ namespace Telemachus
 
         [TelemetryAPI("r.resourceFor",
             "Live resources for a single part keyed by flightID. " +
-            "Returns { resourceName: { amount, maxAmount } }; empty object " +
-            "if the part has no resources or the flightID isn't found.",
+            "Returns { resourceName: { amount, maxAmount, flow?, nominalFlow? } }. " +
+            "amount / maxAmount cover storage; flow is signed units/sec " +
+            "(positive = producing, negative = consuming) summed across the " +
+            "part's modules; nominalFlow is the 100%-efficiency cap. " +
+            "Both are omitted when the part contributes none, when no module " +
+            "supports a nominal (e.g. engines), or when nominal equals flow. " +
+            "Rows are emitted for resources the part contributes flow to even " +
+            "when storage is zero (RTGs, solar panels). Empty object when the " +
+            "flightID isn't found.",
             Plotable = false,
             Category = "resource",
             ReturnType = "object",
             Params = "uint flightId")]
         object ResourceFor(DataSources ds)
         {
-            var result = new Dictionary<string, object>();
-            if (ds.args == null || ds.args.Count == 0) return result;
-            if (!uint.TryParse(ds.args[0], out var flightId)) return result;
-            if (ds.vessel == null || ds.vessel.parts == null) return result;
+            if (ds.args == null || ds.args.Count == 0)
+                return new Dictionary<string, object>();
+            if (!uint.TryParse(ds.args[0], out var flightId))
+                return new Dictionary<string, object>();
+            if (ds.vessel == null || ds.vessel.parts == null)
+                return new Dictionary<string, object>();
 
             foreach (var part in ds.vessel.parts)
             {
                 if (part == null || part.flightID != flightId) continue;
-                if (part.Resources == null) return result;
-                foreach (var res in part.Resources)
+                var rows = new Dictionary<string, FlowRow>();
+                // Storage first — seeds amount / maxAmount for every stored resource.
+                if (part.Resources != null)
                 {
-                    if (res == null) continue;
-                    result[res.resourceName ?? string.Empty] = new Dictionary<string, object>
+                    foreach (var res in part.Resources)
                     {
-                        ["amount"] = res.amount,
-                        ["maxAmount"] = res.maxAmount,
-                    };
+                        if (res == null || string.IsNullOrEmpty(res.resourceName)) continue;
+                        var row = Ensure(rows, res.resourceName);
+                        row.amount = res.amount;
+                        row.maxAmount = res.maxAmount;
+                    }
                 }
-                return result;
+                // Module flow contributions. Per-module try/catch so one bad
+                // module type / cast doesn't crater the whole payload.
+                if (part.Modules != null)
+                {
+                    foreach (var module in part.Modules)
+                    {
+                        if (module == null) continue;
+                        try { AddModuleFlow(module, rows); }
+                        catch { /* skip silently */ }
+                    }
+                }
+                return Serialize(rows);
             }
-            return result;
+            return new Dictionary<string, object>();
+        }
+
+        /// Internal accumulator for one resource's row on a part. Stored in a
+        /// Dictionary keyed by resource name; serialised at the end.
+        private class FlowRow
+        {
+            public double amount;
+            public double maxAmount;
+            public double? flow;
+            public double? nominalFlow;
+            /// Goes true when any contributing module didn't supply a nominal
+            /// (e.g. engines, where "nominal at full throttle" needs more
+            /// integration than this v1 does). Suppresses nominalFlow in the
+            /// output so the client doesn't compare a partial nominal against
+            /// a full flow total.
+            public bool nominalIncomplete;
+        }
+
+        private static FlowRow Ensure(Dictionary<string, FlowRow> rows, string name)
+        {
+            if (!rows.TryGetValue(name, out var row))
+            {
+                row = new FlowRow();
+                rows[name] = row;
+            }
+            return row;
+        }
+
+        private static void AddFlow(
+            Dictionary<string, FlowRow> rows,
+            string name,
+            double current,
+            double? nominal)
+        {
+            if (string.IsNullOrEmpty(name)) return;
+            var row = Ensure(rows, name);
+            row.flow = (row.flow ?? 0.0) + current;
+            if (nominal.HasValue)
+                row.nominalFlow = (row.nominalFlow ?? 0.0) + nominal.Value;
+            else
+                row.nominalIncomplete = true;
+        }
+
+        private static void AddModuleFlow(PartModule module, Dictionary<string, FlowRow> rows)
+        {
+            switch (module)
+            {
+                case ModuleDeployableSolarPanel solar:
+                    // chargeRate × efficiencyMult is the at-full-deployment cap
+                    // (sunlit, no shading). flowRate is the live value.
+                    AddFlow(
+                        rows,
+                        solar.resourceName ?? "ElectricCharge",
+                        solar.flowRate,
+                        solar.chargeRate * solar.efficiencyMult);
+                    break;
+
+                case ModuleGenerator gen:
+                    if (!gen.generatorIsActive) break;
+                    if (gen.resHandler != null && gen.resHandler.outputResources != null)
+                    {
+                        foreach (var output in gen.resHandler.outputResources)
+                        {
+                            if (output == null) continue;
+                            AddFlow(rows, output.name, output.rate * gen.efficiency, output.rate);
+                        }
+                    }
+                    if (gen.resHandler != null && gen.resHandler.inputResources != null)
+                    {
+                        foreach (var input in gen.resHandler.inputResources)
+                        {
+                            if (input == null) continue;
+                            AddFlow(rows, input.name, -input.rate * gen.efficiency, -input.rate);
+                        }
+                    }
+                    break;
+
+                case ModuleResourceConverter conv:
+                    // ModuleResourceHarvester extends ModuleResourceConverter, so
+                    // a single case covers ISRU + drills + fuel cells. lastTimeFactor
+                    // is the current rate factor (0..1+); outputList / inputList
+                    // are full-throttle ratios.
+                    if (!conv.IsActivated) break;
+                    if (conv.outputList != null)
+                    {
+                        // ResourceRatio is a value type — iterate by value, no
+                        // null check needed.
+                        foreach (var output in conv.outputList)
+                        {
+                            AddFlow(
+                                rows,
+                                output.ResourceName,
+                                output.Ratio * conv.lastTimeFactor,
+                                output.Ratio);
+                        }
+                    }
+                    if (conv.inputList != null)
+                    {
+                        foreach (var input in conv.inputList)
+                        {
+                            AddFlow(
+                                rows,
+                                input.ResourceName,
+                                -input.Ratio * conv.lastTimeFactor,
+                                -input.Ratio);
+                        }
+                    }
+                    break;
+
+                case ModuleEngines engine:
+                    // ModuleEnginesFX inherits ModuleEngines so this case
+                    // catches both. Per-propellant consumption in units/sec at
+                    // current throttle. No nominal — at full throttle it varies
+                    // by propellant ratio + density and isn't a one-liner; v1
+                    // marks the row's nominal as incomplete so the client
+                    // doesn't compare a partial nominal against a full flow
+                    // total.
+                    if (!engine.EngineIgnited || engine.flameout) break;
+                    if (engine.propellants != null)
+                    {
+                        foreach (var prop in engine.propellants)
+                        {
+                            if (prop == null || string.IsNullOrEmpty(prop.name)) continue;
+                            AddFlow(rows, prop.name, -prop.currentRequirement, null);
+                        }
+                    }
+                    break;
+            }
+        }
+
+        private static object Serialize(Dictionary<string, FlowRow> rows)
+        {
+            var output = new Dictionary<string, object>();
+            foreach (var kv in rows)
+            {
+                var dict = new Dictionary<string, object>
+                {
+                    ["amount"] = kv.Value.amount,
+                    ["maxAmount"] = kv.Value.maxAmount,
+                };
+                if (kv.Value.flow.HasValue)
+                {
+                    dict["flow"] = kv.Value.flow.Value;
+                    if (kv.Value.nominalFlow.HasValue &&
+                        !kv.Value.nominalIncomplete &&
+                        Math.Abs(kv.Value.nominalFlow.Value - kv.Value.flow.Value) > 1e-9)
+                    {
+                        dict["nominalFlow"] = kv.Value.nominalFlow.Value;
+                    }
+                }
+                output[kv.Key] = dict;
+            }
+            return output;
         }
 
         private List<PartResource> GetResourceValues(DataSources datasources)

--- a/Telemachus/src/ResourceHandlers.cs
+++ b/Telemachus/src/ResourceHandlers.cs
@@ -251,10 +251,16 @@ namespace Telemachus
                     if (!engine.EngineIgnited || engine.flameout) break;
                     if (engine.propellants != null)
                     {
+                        // Propellant.currentRequirement is units-per-physics-frame
+                        // (set by KSP each FixedUpdate). Divide by the physics
+                        // fixedDeltaTime to convert to units/sec, matching the
+                        // unit convention used by every other dispatch case.
+                        float dt = TimeWarp.fixedDeltaTime;
+                        if (dt <= 0f) break;
                         foreach (var prop in engine.propellants)
                         {
                             if (prop == null || string.IsNullOrEmpty(prop.name)) continue;
-                            AddFlow(rows, prop.name, -prop.currentRequirement, null);
+                            AddFlow(rows, prop.name, -prop.currentRequirement / dt, null);
                         }
                     }
                     break;

--- a/Telemachus/src/ResourceHandlers.cs
+++ b/Telemachus/src/ResourceHandlers.cs
@@ -78,6 +78,39 @@ namespace Telemachus
             return names;
         }
 
+        [TelemetryAPI("r.resourceFor",
+            "Live resources for a single part keyed by flightID. " +
+            "Returns { resourceName: { amount, maxAmount } }; empty object " +
+            "if the part has no resources or the flightID isn't found.",
+            Plotable = false,
+            Category = "resource",
+            ReturnType = "object",
+            Params = "uint flightId")]
+        object ResourceFor(DataSources ds)
+        {
+            var result = new Dictionary<string, object>();
+            if (ds.args == null || ds.args.Count == 0) return result;
+            if (!uint.TryParse(ds.args[0], out var flightId)) return result;
+            if (ds.vessel == null || ds.vessel.parts == null) return result;
+
+            foreach (var part in ds.vessel.parts)
+            {
+                if (part == null || part.flightID != flightId) continue;
+                if (part.Resources == null) return result;
+                foreach (var res in part.Resources)
+                {
+                    if (res == null) continue;
+                    result[res.resourceName ?? string.Empty] = new Dictionary<string, object>
+                    {
+                        ["amount"] = res.amount,
+                        ["maxAmount"] = res.maxAmount,
+                    };
+                }
+                return result;
+            }
+            return result;
+        }
+
         private List<PartResource> GetResourceValues(DataSources datasources)
         {
             resourceCache.vessel = datasources.vessel;

--- a/Telemachus/src/ResourceHandlers.cs
+++ b/Telemachus/src/ResourceHandlers.cs
@@ -264,6 +264,103 @@ namespace Telemachus
                         }
                     }
                     break;
+
+                case ModuleAlternator alt:
+                    // Engine alternators produce EC scaled by their paired
+                    // engine's throttle. `outputRate` is the live computed
+                    // value (already in units/sec at current state) — KSP
+                    // wires up engine ↔ alternator on OnStart and the
+                    // module's FixedUpdate keeps `outputRate` current.
+                    // Stock alternators output ElectricCharge; the resource
+                    // name isn't exposed as a public field, so we hardcode
+                    // to EC (the only resource any vanilla alternator emits).
+                    // nominalFlow is unavailable on this module (no public
+                    // "max output" field), so the row is marked incomplete.
+                    if (alt.outputRate != 0f)
+                    {
+                        AddFlow(rows, "ElectricCharge", alt.outputRate, null);
+                    }
+                    break;
+
+                case ModuleDataTransmitter antenna:
+                    // Stock antennas only draw EC during active transmission.
+                    // packetResourceCost is EC per packet; packetInterval is
+                    // seconds per packet; so per-sec rate during transmit is
+                    // cost / interval. When idle the antenna draws nothing,
+                    // which means no row is emitted (the storage seed handled
+                    // by the outer loop already covers the EC capacity if any).
+                    if (antenna.IsBusy() && antenna.packetInterval > 0f)
+                    {
+                        double rate = antenna.packetResourceCost / antenna.packetInterval;
+                        AddFlow(rows, "ElectricCharge", -rate, -rate);
+                    }
+                    break;
+
+                case ModuleCommand cmd:
+                    // Probe cores and crewed pods draw EC for control. The
+                    // resHandler input list captures the always-on drain.
+                    // Hibernation zeroes the draw (with a small idle draw
+                    // KSP sometimes leaves on, but exposing that requires
+                    // additional reflection — skip for v1).
+                    if (cmd.hibernation) break;
+                    if (cmd.resHandler != null && cmd.resHandler.inputResources != null)
+                    {
+                        foreach (var input in cmd.resHandler.inputResources)
+                        {
+                            if (input == null || string.IsNullOrEmpty(input.name)) continue;
+                            AddFlow(rows, input.name, -input.rate, -input.rate);
+                        }
+                    }
+                    break;
+
+                case ModuleReactionWheel wheel:
+                    // Reaction wheels draw EC scaled by control intensity.
+                    // KSP doesn't expose the live draw on a public field
+                    // (it's computed inside FixedUpdate against pilot input
+                    // + SAS hold), so v1 approximates with the catalog max
+                    // rate when the wheel is Active. This overstates the
+                    // draw when idle / lightly used; nominal is the same
+                    // so efficiency reads ≈ 100% — clients can treat it
+                    // as a worst-case ceiling rather than a true live rate.
+                    if (wheel.State != ModuleReactionWheel.WheelState.Active) break;
+                    if (wheel.resHandler != null && wheel.resHandler.inputResources != null)
+                    {
+                        foreach (var input in wheel.resHandler.inputResources)
+                        {
+                            if (input == null || string.IsNullOrEmpty(input.name)) continue;
+                            AddFlow(rows, input.name, -input.rate, -input.rate);
+                        }
+                    }
+                    break;
+
+                case ModuleLight light:
+                    if (!light.isOn) break;
+                    if (light.resourceAmount > 0f)
+                    {
+                        AddFlow(
+                            rows,
+                            "ElectricCharge",
+                            -light.resourceAmount,
+                            -light.resourceAmount);
+                    }
+                    break;
+
+                case TelemachusPowerDrain antennaDrain:
+                    // This mod's own data-link antenna. powerConsumption is
+                    // the live EC/sec rate (already in units/sec — set inside
+                    // OnUpdate based on link state). Zero when toggled off or
+                    // when the link has dropped due to insufficient power.
+                    if (antennaDrain.activeToggle
+                        && antennaDrain.isActive
+                        && antennaDrain.powerConsumption > 0f)
+                    {
+                        AddFlow(
+                            rows,
+                            "ElectricCharge",
+                            -antennaDrain.powerConsumption,
+                            null);
+                    }
+                    break;
             }
         }
 

--- a/Telemachus/src/ResourceHandlers.cs
+++ b/Telemachus/src/ResourceHandlers.cs
@@ -276,9 +276,32 @@ namespace Telemachus
                     // to EC (the only resource any vanilla alternator emits).
                     // nominalFlow is unavailable on this module (no public
                     // "max output" field), so the row is marked incomplete.
-                    if (alt.outputRate != 0f)
+                    //
+                    // Gate on sibling engine state: KSP keeps `outputRate`
+                    // at its last-non-zero value after a flameout, so without
+                    // this check we'd emit ghost EC long after the engine
+                    // stopped thrusting. Observed live during the 2026-05-15
+                    // staging test — a flamed-out engine on a 1-part debris
+                    // vessel reported +4.70 EC/s indefinitely.
                     {
-                        AddFlow(rows, "ElectricCharge", alt.outputRate, null);
+                        bool engineActive = false;
+                        if (alt.part != null && alt.part.Modules != null)
+                        {
+                            foreach (var sibling in alt.part.Modules)
+                            {
+                                if (sibling is ModuleEngines eng
+                                    && eng.EngineIgnited
+                                    && !eng.flameout)
+                                {
+                                    engineActive = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if (engineActive && alt.outputRate != 0f)
+                        {
+                            AddFlow(rows, "ElectricCharge", alt.outputRate, null);
+                        }
                     }
                     break;
 

--- a/Telemachus/src/ThermalDataLinkHandler.cs
+++ b/Telemachus/src/ThermalDataLinkHandler.cs
@@ -231,6 +231,37 @@ namespace Telemachus
             }
         }
 
+        // --- Per-part thermal lookup ---
+
+        [TelemetryAPI("therm.part",
+            "Thermal state for a single part keyed by flightID. Returns " +
+            "{ temperature, maxTemperature, temperatureK, maxTemperatureK }; " +
+            "null if the flightID isn't found. Core part temperature only — " +
+            "skin temperature is not exposed here.",
+            Plotable = false,
+            Category = "thermal",
+            ReturnType = "object",
+            Params = "uint flightId")]
+        object PartFor(DataSources ds)
+        {
+            if (ds.args == null || ds.args.Count == 0) return null;
+            if (!uint.TryParse(ds.args[0], out var flightId)) return null;
+            if (ds.vessel == null || ds.vessel.parts == null) return null;
+
+            foreach (var part in ds.vessel.parts)
+            {
+                if (part == null || part.flightID != flightId) continue;
+                return new Dictionary<string, object>
+                {
+                    ["temperature"] = part.temperature - 273.15,
+                    ["maxTemperature"] = part.maxTemp - 273.15,
+                    ["temperatureK"] = part.temperature,
+                    ["maxTemperatureK"] = part.maxTemp,
+                };
+            }
+            return null;
+        }
+
         protected override int pausedHandler() => PausedDataLinkHandler.partPaused();
     }
 }

--- a/docs/api-schema.json
+++ b/docs/api-schema.json
@@ -3897,7 +3897,7 @@
   },
   {
     "key": "r.resourceFor",
-    "description": "Live resources for a single part keyed by flightID. Returns { resourceName: { amount, maxAmount } }; empty object if the part has no resources or the flightID isn't found.",
+    "description": "Live resources for a single part keyed by flightID. Returns { resourceName: { amount, maxAmount, flow?, nominalFlow? } }. amount / maxAmount cover storage; flow is signed units/sec (positive = producing, negative = consuming) summed across the part's modules; nominalFlow is the 100%-efficiency cap. Both are omitted when the part contributes none, when no module supports a nominal (e.g. engines), or when nominal equals flow. Rows are emitted for resources the part contributes flow to even when storage is zero (RTGs, solar panels). Empty object when the flightID isn't found.",
     "units": "UNITLESS",
     "plotable": false,
     "isAction": false,
@@ -5885,7 +5885,7 @@
   },
   {
     "key": "v.topology",
-    "description": "Active vessel topology: rootFlightId + per-part flightId, persistentId, parentFlightId, name, title, manufacturer, category, inverseStage, crewCapacity, maxTemp, crashTolerance, dryMass, orgPos[x,y,z], bounds.size{x,y,z}, modules[]. Cached and event-invalidated — subscribe to v.topologySeq to detect changes rather than streaming this key.",
+    "description": "Active vessel topology: rootFlightId + per-part flightId, persistentId, parentFlightId, fuelLineTarget (flightId of the receiving tank for fuel-line parts, null otherwise), name, title, manufacturer, category, inverseStage, crewCapacity, maxTemp, crashTolerance, dryMass, orgPos[x,y,z], up[x,y,z] (part-local up in vessel frame), bounds.size{x,y,z}, bounds.center{x,y,z} (mesh-center offset from orgPos in vessel-local frame — already rotated by orgRot; add it to orgPos to get the mesh centre in assembly space), modules[]. Cached and event-invalidated — subscribe to v.topologySeq to detect changes rather than streaming this key.",
     "units": "UNITLESS",
     "plotable": false,
     "isAction": false,

--- a/docs/api-schema.json
+++ b/docs/api-schema.json
@@ -5512,6 +5512,18 @@
     "declaringClass": "VesselDataLinkHandler"
   },
   {
+    "key": "v.partState",
+    "description": "Live deployable / behavioural state for a single part keyed by flightID. Returns { seq, modules: [{ type, state, ...extras }] }. Cached server-side and invalidated on staging, action-group events, vessel modifications, part death / undock / couple, and PAW dismiss; plus a 10s backstop covering player right-click interactions that don't fire a global event. Consumers subscribe and dedup on the seq field rather than re-processing the modules array on every push.",
+    "units": "UNITLESS",
+    "plotable": false,
+    "isAction": false,
+    "alwaysEvaluable": false,
+    "category": "vessel",
+    "returnType": "object",
+    "params": "uint flightId",
+    "declaringClass": "PartStateDataLinkHandler"
+  },
+  {
     "key": "v.perturbation",
     "description": "Orbital Perturbation Magnitude",
     "units": "UNITLESS",

--- a/docs/api-schema.json
+++ b/docs/api-schema.json
@@ -39,8 +39,7 @@
     "alwaysEvaluable": true,
     "category": "system",
     "returnType": "object",
-    "declaringClass": "APIDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/SystemHandlers.cs"
+    "declaringClass": "APIDataLinkHandler"
   },
   {
     "key": "a.physicsMode",
@@ -51,8 +50,7 @@
     "alwaysEvaluable": true,
     "category": "system",
     "returnType": "string",
-    "declaringClass": "APIDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/SystemHandlers.cs"
+    "declaringClass": "APIDataLinkHandler"
   },
   {
     "key": "a.schema",
@@ -63,8 +61,7 @@
     "alwaysEvaluable": true,
     "category": "system",
     "returnType": "object",
-    "declaringClass": "APIDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/SystemHandlers.cs"
+    "declaringClass": "APIDataLinkHandler"
   },
   {
     "key": "a.version",
@@ -75,8 +72,7 @@
     "alwaysEvaluable": true,
     "category": "system",
     "returnType": "string",
-    "declaringClass": "APIDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/SystemHandlers.cs"
+    "declaringClass": "APIDataLinkHandler"
   },
   {
     "key": "alarm.count",
@@ -87,8 +83,7 @@
     "alwaysEvaluable": false,
     "category": "alarm",
     "returnType": "int",
-    "declaringClass": "AlarmClockDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AlarmClockHandlers.cs"
+    "declaringClass": "AlarmClockDataLinkHandler"
   },
   {
     "key": "alarm.list",
@@ -100,8 +95,7 @@
     "category": "alarm",
     "returnType": "object",
     "formatter": "AlarmList",
-    "declaringClass": "AlarmClockDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AlarmClockHandlers.cs"
+    "declaringClass": "AlarmClockDataLinkHandler"
   },
   {
     "key": "alarm.nextAlarm",
@@ -113,8 +107,7 @@
     "category": "alarm",
     "returnType": "object",
     "formatter": "Alarm",
-    "declaringClass": "AlarmClockDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AlarmClockHandlers.cs"
+    "declaringClass": "AlarmClockDataLinkHandler"
   },
   {
     "key": "alarm.timeToNext",
@@ -125,8 +118,7 @@
     "alwaysEvaluable": false,
     "category": "alarm",
     "returnType": "double",
-    "declaringClass": "AlarmClockDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AlarmClockHandlers.cs"
+    "declaringClass": "AlarmClockDataLinkHandler"
   },
   {
     "key": "astg.active",
@@ -135,8 +127,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.activeTransfer",
@@ -145,8 +136,7 @@
     "plotable": false,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.available",
@@ -155,8 +145,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": true,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.createManeuver",
@@ -165,8 +154,7 @@
     "plotable": true,
     "isAction": true,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.errorCondition",
@@ -175,8 +163,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.hyperbolicOrbit",
@@ -185,8 +172,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.nextBurnCountdown",
@@ -195,8 +181,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.nextBurnTime",
@@ -205,8 +190,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.nextDeltaV",
@@ -215,8 +199,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.nextDestination",
@@ -225,8 +208,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.retrogradeOrbit",
@@ -235,8 +217,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.transfer",
@@ -245,8 +226,7 @@
     "plotable": false,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.transferCount",
@@ -255,8 +235,7 @@
     "plotable": true,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.transfers",
@@ -265,8 +244,7 @@
     "plotable": false,
     "isAction": false,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "astg.warpToBurn",
@@ -275,8 +253,7 @@
     "plotable": true,
     "isAction": true,
     "alwaysEvaluable": false,
-    "declaringClass": "AstrogatorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/AstrogatorDataLinkHandler.cs"
+    "declaringClass": "AstrogatorDataLinkHandler"
   },
   {
     "key": "b.angularV",
@@ -288,8 +265,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.atmosphere",
@@ -301,8 +277,7 @@
     "category": "body",
     "returnType": "bool",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.atmosphereContainsOxygen",
@@ -314,8 +289,7 @@
     "category": "body",
     "returnType": "bool",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.description",
@@ -327,8 +301,7 @@
     "category": "body",
     "returnType": "string",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.geeASL",
@@ -340,8 +313,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.hillSphere",
@@ -353,8 +325,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.index",
@@ -366,8 +337,7 @@
     "category": "body",
     "returnType": "int",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.mass",
@@ -379,8 +349,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.maxAtmosphere",
@@ -392,8 +361,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.name",
@@ -405,8 +373,7 @@
     "category": "body",
     "returnType": "string",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.number",
@@ -417,8 +384,7 @@
     "alwaysEvaluable": false,
     "category": "body",
     "returnType": "int",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.ApA",
@@ -430,8 +396,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.argumentOfPeriapsis",
@@ -443,8 +408,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.eccentricity",
@@ -456,8 +420,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.gravParameter",
@@ -469,8 +432,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.inclination",
@@ -482,8 +444,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.lan",
@@ -495,8 +456,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.maae",
@@ -508,8 +468,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.PeA",
@@ -521,8 +480,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.period",
@@ -534,8 +492,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.phaseAngle",
@@ -547,8 +504,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.relativeVelocity",
@@ -560,8 +516,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.sma",
@@ -573,8 +528,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.timeOfPeriapsisPassage",
@@ -586,8 +540,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.timeToAp",
@@ -599,8 +552,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.timeToPe",
@@ -612,8 +564,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.timeToTransition1",
@@ -625,8 +576,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.timeToTransition2",
@@ -638,8 +588,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.trueAnomaly",
@@ -651,8 +600,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.o.truePositionAtUT",
@@ -665,8 +613,7 @@
     "returnType": "Vector3d",
     "params": "int bodyId, double UT",
     "formatter": "Vector3d",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.ocean",
@@ -678,8 +625,7 @@
     "category": "body",
     "returnType": "bool",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.orbitingBodies",
@@ -692,8 +638,7 @@
     "returnType": "string[]",
     "params": "int bodyId",
     "formatter": "StringArray",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.position",
@@ -706,8 +651,7 @@
     "returnType": "Vector3d",
     "params": "int bodyId",
     "formatter": "Vector3d",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.radius",
@@ -719,8 +663,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.referenceBody",
@@ -732,8 +675,7 @@
     "category": "body",
     "returnType": "string",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.rotates",
@@ -745,8 +687,7 @@
     "category": "body",
     "returnType": "bool",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.rotationAngle",
@@ -758,8 +699,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.rotationPeriod",
@@ -771,8 +711,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.soi",
@@ -784,8 +723,7 @@
     "category": "body",
     "returnType": "double",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.tidallyLocked",
@@ -797,8 +735,7 @@
     "category": "body",
     "returnType": "bool",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "b.timeWarpAltitudeLimits",
@@ -810,8 +747,7 @@
     "category": "body",
     "returnType": "object",
     "params": "int bodyId",
-    "declaringClass": "BodyDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "BodyDataLinkHandler"
   },
   {
     "key": "career.funds",
@@ -822,8 +758,7 @@
     "alwaysEvaluable": true,
     "category": "career",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "career.mode",
@@ -834,8 +769,7 @@
     "alwaysEvaluable": true,
     "category": "career",
     "returnType": "string",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "career.reputation",
@@ -846,8 +780,7 @@
     "alwaysEvaluable": true,
     "category": "career",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "career.science",
@@ -858,8 +791,7 @@
     "alwaysEvaluable": true,
     "category": "career",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "comm.connected",
@@ -870,8 +802,7 @@
     "alwaysEvaluable": false,
     "category": "comms",
     "returnType": "bool",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "comm.controlState",
@@ -882,8 +813,7 @@
     "alwaysEvaluable": false,
     "category": "comms",
     "returnType": "int",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "comm.controlStateName",
@@ -894,8 +824,7 @@
     "alwaysEvaluable": false,
     "category": "comms",
     "returnType": "string",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "comm.signalDelay",
@@ -906,8 +835,7 @@
     "alwaysEvaluable": false,
     "category": "comms",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "comm.signalStrength",
@@ -918,8 +846,7 @@
     "alwaysEvaluable": false,
     "category": "comms",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "dock.ax",
@@ -930,8 +857,7 @@
     "alwaysEvaluable": false,
     "category": "docking",
     "returnType": "double",
-    "declaringClass": "DockingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "DockingDataLinkHandler"
   },
   {
     "key": "dock.ay",
@@ -942,8 +868,7 @@
     "alwaysEvaluable": false,
     "category": "docking",
     "returnType": "double",
-    "declaringClass": "DockingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "DockingDataLinkHandler"
   },
   {
     "key": "dock.az",
@@ -954,8 +879,7 @@
     "alwaysEvaluable": false,
     "category": "docking",
     "returnType": "double",
-    "declaringClass": "DockingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "DockingDataLinkHandler"
   },
   {
     "key": "dock.x",
@@ -966,8 +890,7 @@
     "alwaysEvaluable": false,
     "category": "docking",
     "returnType": "double",
-    "declaringClass": "DockingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "DockingDataLinkHandler"
   },
   {
     "key": "dock.y",
@@ -978,8 +901,7 @@
     "alwaysEvaluable": false,
     "category": "docking",
     "returnType": "double",
-    "declaringClass": "DockingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "DockingDataLinkHandler"
   },
   {
     "key": "dv.ready",
@@ -990,8 +912,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "double",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stage",
@@ -1004,8 +925,7 @@
     "returnType": "object",
     "params": "int stage",
     "formatter": "DeltaVStageInfo",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageBurnTime",
@@ -1017,8 +937,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageCount",
@@ -1029,8 +948,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "int",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageDryMass",
@@ -1042,8 +960,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageDVActual",
@@ -1055,8 +972,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageDVASL",
@@ -1068,8 +984,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageDVVac",
@@ -1081,8 +996,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageEndMass",
@@ -1094,8 +1008,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageFuelMass",
@@ -1107,8 +1020,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageISPActual",
@@ -1120,8 +1032,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageISPASL",
@@ -1133,8 +1044,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageISPVac",
@@ -1146,8 +1056,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageMass",
@@ -1159,8 +1068,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stages",
@@ -1172,8 +1080,7 @@
     "category": "deltav",
     "returnType": "object",
     "formatter": "DeltaVStageInfoList",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageStartMass",
@@ -1185,8 +1092,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageThrustActual",
@@ -1198,8 +1104,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageThrustASL",
@@ -1211,8 +1116,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageThrustVac",
@@ -1224,8 +1128,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageTWRActual",
@@ -1237,8 +1140,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageTWRASL",
@@ -1250,8 +1152,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.stageTWRVac",
@@ -1263,8 +1164,7 @@
     "category": "deltav",
     "returnType": "double",
     "params": "int stage",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.totalBurnTime",
@@ -1275,8 +1175,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "double",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.totalDVActual",
@@ -1287,8 +1186,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "double",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.totalDVASL",
@@ -1299,8 +1197,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "double",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "dv.totalDVVac",
@@ -1311,8 +1208,7 @@
     "alwaysEvaluable": false,
     "category": "deltav",
     "returnType": "double",
-    "declaringClass": "DeltaVDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/DeltaVHandlers.cs"
+    "declaringClass": "DeltaVDataLinkHandler"
   },
   {
     "key": "f.abort",
@@ -1453,8 +1349,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.killRot",
@@ -1465,8 +1360,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.light",
@@ -1487,8 +1381,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.pitchTrim",
@@ -1499,8 +1392,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.precisionControl",
@@ -1531,8 +1423,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.rollTrim",
@@ -1543,8 +1434,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.sas",
@@ -1565,8 +1455,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.sasMode",
@@ -1577,8 +1466,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "string",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.setPitchTrim",
@@ -1590,8 +1478,7 @@
     "category": "flight",
     "returnType": "int",
     "params": "float trim",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.setRollTrim",
@@ -1603,8 +1490,7 @@
     "category": "flight",
     "returnType": "int",
     "params": "float trim",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.setSASMode",
@@ -1616,8 +1502,7 @@
     "category": "flight",
     "returnType": "string",
     "params": "string mode",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.setThrottle",
@@ -1639,8 +1524,7 @@
     "category": "flight",
     "returnType": "int",
     "params": "float trim",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.stage",
@@ -1660,8 +1544,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.throttleDown",
@@ -1708,8 +1591,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.yawInput",
@@ -1720,8 +1602,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.yawTrim",
@@ -1732,8 +1613,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.yInput",
@@ -1744,8 +1624,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "f.zInput",
@@ -1756,8 +1635,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "double",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "far.aoa",
@@ -1769,8 +1647,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.available",
@@ -1782,8 +1659,7 @@
     "category": "far",
     "returnType": "bool",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.ballisticCoeff",
@@ -1795,8 +1671,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.decreaseFlaps",
@@ -1808,8 +1683,7 @@
     "category": "far",
     "returnType": "bool",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.dragCoeff",
@@ -1821,8 +1695,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.dynPres",
@@ -1834,8 +1707,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.flapSetting",
@@ -1847,8 +1719,7 @@
     "category": "far",
     "returnType": "int",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.increaseFlaps",
@@ -1860,8 +1731,7 @@
     "category": "far",
     "returnType": "bool",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.liftCoeff",
@@ -1873,8 +1743,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.refArea",
@@ -1886,8 +1755,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.setSpoilers",
@@ -1900,8 +1768,7 @@
     "returnType": "bool",
     "params": "bool active",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.sideslip",
@@ -1913,8 +1780,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.spoiler",
@@ -1926,8 +1792,7 @@
     "category": "far",
     "returnType": "bool",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.stallFrac",
@@ -1939,8 +1804,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.termVel",
@@ -1952,8 +1816,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.tsfc",
@@ -1965,8 +1828,7 @@
     "category": "far",
     "returnType": "double",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "far.voxelized",
@@ -1978,8 +1840,7 @@
     "category": "far",
     "returnType": "bool",
     "requiresMod": "far",
-    "declaringClass": "FARDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FARDataLinkHandler.cs"
+    "declaringClass": "FARDataLinkHandler"
   },
   {
     "key": "kerbalism.available",
@@ -1991,8 +1852,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.breathable",
@@ -2004,8 +1864,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.co2Level",
@@ -2017,8 +1876,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.connection",
@@ -2030,8 +1888,7 @@
     "category": "kerbalism",
     "returnType": "object",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.connectionLinked",
@@ -2043,8 +1900,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.connectionRate",
@@ -2056,8 +1912,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.connectionTransmitting",
@@ -2069,8 +1924,7 @@
     "category": "kerbalism",
     "returnType": "int",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.crew",
@@ -2082,8 +1936,7 @@
     "category": "kerbalism",
     "returnType": "object",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.critical",
@@ -2095,8 +1948,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.drivesCapacity",
@@ -2108,8 +1960,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.drivesFreeSpace",
@@ -2121,8 +1972,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.envStormRadiation",
@@ -2134,8 +1984,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.envTempDiff",
@@ -2147,8 +1996,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.envTemperature",
@@ -2160,8 +2008,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.experimentRunning",
@@ -2173,8 +2020,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.features",
@@ -2186,8 +2032,7 @@
     "category": "kerbalism",
     "returnType": "object",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatComfort",
@@ -2199,8 +2044,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatLivingSpace",
@@ -2212,8 +2056,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatPressure",
@@ -2225,8 +2068,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatRadiation",
@@ -2238,8 +2080,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatSurface",
@@ -2251,8 +2092,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.habitatVolume",
@@ -2264,8 +2104,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.inAtmosphere",
@@ -2277,8 +2116,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.innerBelt",
@@ -2290,8 +2128,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.magnetosphere",
@@ -2303,8 +2140,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.malfunction",
@@ -2316,8 +2152,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.outerBelt",
@@ -2329,8 +2164,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.radiation",
@@ -2342,8 +2176,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.radiationEnabled",
@@ -2355,8 +2188,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.radiationShielding",
@@ -2368,8 +2200,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.solarExposure",
@@ -2381,8 +2212,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarActivity",
@@ -2394,8 +2224,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarStormDuration",
@@ -2407,8 +2236,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarStormIncoming",
@@ -2420,8 +2248,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarStormInProgress",
@@ -2433,8 +2260,7 @@
     "category": "kerbalism",
     "returnType": "bool",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarStormStartTime",
@@ -2446,8 +2272,7 @@
     "category": "kerbalism",
     "returnType": "double",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "kerbalism.stellarStormState",
@@ -2459,8 +2284,7 @@
     "category": "kerbalism",
     "returnType": "int",
     "requiresMod": "kerbalism",
-    "declaringClass": "KerbalismDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/KerbalismDataLinkHandler.cs"
+    "declaringClass": "KerbalismDataLinkHandler"
   },
   {
     "key": "land.bestSpeedAtImpact",
@@ -2471,8 +2295,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.predictedAlt",
@@ -2483,8 +2306,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.predictedLat",
@@ -2495,8 +2317,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.predictedLon",
@@ -2507,8 +2328,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.slopeAngle",
@@ -2519,8 +2339,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.speedAtImpact",
@@ -2531,8 +2350,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.suicideBurnCountdown",
@@ -2543,8 +2361,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "land.timeToImpact",
@@ -2555,8 +2372,7 @@
     "alwaysEvaluable": false,
     "category": "landing",
     "returnType": "double",
-    "declaringClass": "LandingDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/LandingDataLinkHandler.cs"
+    "declaringClass": "LandingDataLinkHandler"
   },
   {
     "key": "m.mapIsEnabled",
@@ -2567,8 +2383,7 @@
     "alwaysEvaluable": false,
     "category": "map",
     "returnType": "bool",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "mj.available",
@@ -2580,8 +2395,7 @@
     "category": "mechjeb",
     "returnType": "bool",
     "requiresMod": "mechjeb",
-    "declaringClass": "MechJebDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/MechJebDataLinkHandler.cs"
+    "declaringClass": "MechJebDataLinkHandler"
   },
   {
     "key": "mj.node",
@@ -2764,8 +2578,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.heading2",
@@ -2776,8 +2589,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.pitch",
@@ -2788,8 +2600,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.pitch2",
@@ -2800,8 +2611,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawheading",
@@ -2812,8 +2622,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawheading2",
@@ -2824,8 +2633,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawpitch",
@@ -2836,8 +2644,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawpitch2",
@@ -2848,8 +2655,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawroll",
@@ -2860,8 +2666,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.rawroll2",
@@ -2872,8 +2677,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.roll",
@@ -2884,8 +2688,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "n.roll2",
@@ -2896,8 +2699,7 @@
     "alwaysEvaluable": false,
     "category": "navigation",
     "returnType": "double",
-    "declaringClass": "NavBallDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "NavBallDataLinkHandler"
   },
   {
     "key": "o.addManeuverNode",
@@ -2910,8 +2712,7 @@
     "returnType": "object",
     "params": "float ut, float x, float y, float z",
     "formatter": "ManeuverNode",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.anVec",
@@ -2923,8 +2724,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.ApA",
@@ -2935,8 +2735,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.ApR",
@@ -2947,8 +2746,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.argumentOfPeriapsis",
@@ -2959,8 +2757,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.closestEncounterBody",
@@ -2971,8 +2768,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.closestTgtApprUT",
@@ -2983,8 +2779,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.eccentricAnomaly",
@@ -2995,8 +2790,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.eccentricity",
@@ -3007,8 +2801,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.eccVec",
@@ -3020,8 +2813,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.encounterBody",
@@ -3032,8 +2824,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.encounterExists",
@@ -3044,8 +2835,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "int",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.encounterTime",
@@ -3056,8 +2846,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.EndUT",
@@ -3068,8 +2857,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.epoch",
@@ -3080,8 +2868,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.gameLanguage",
@@ -3092,8 +2879,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "LangDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "LangDataLinkHandler"
   },
   {
     "key": "o.h",
@@ -3105,8 +2891,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.inclination",
@@ -3117,8 +2902,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.lan",
@@ -3129,8 +2913,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.maae",
@@ -3141,8 +2924,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes",
@@ -3154,8 +2936,7 @@
     "category": "maneuver",
     "returnType": "object",
     "formatter": "ManeuverNodeList",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.burnVector",
@@ -3168,8 +2949,7 @@
     "returnType": "Vector3d",
     "params": "int id",
     "formatter": "Vector3d",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.count",
@@ -3180,8 +2960,7 @@
     "alwaysEvaluable": false,
     "category": "maneuver",
     "returnType": "int",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.deltaV",
@@ -3194,8 +2973,7 @@
     "returnType": "Vector3d",
     "params": "int id",
     "formatter": "Vector3d",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.deltaVMagnitude",
@@ -3207,8 +2985,7 @@
     "category": "maneuver",
     "returnType": "double",
     "params": "int id",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.orbitPatches",
@@ -3221,8 +2998,7 @@
     "returnType": "object",
     "params": "int id",
     "formatter": "OrbitPatchList",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.relativePositionAtTrueAnomalyForManeuverNodesOrbitPatch",
@@ -3235,8 +3011,7 @@
     "returnType": "Vector3d",
     "params": "int id, int patchIndex, double trueAnomaly",
     "formatter": "Vector3d",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.relativePositionAtUTForManeuverNodesOrbitPatch",
@@ -3249,8 +3024,7 @@
     "returnType": "Vector3d",
     "params": "int id, int patchIndex, double UT",
     "formatter": "Vector3d",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.timeTo",
@@ -3262,8 +3036,7 @@
     "category": "maneuver",
     "returnType": "double",
     "params": "int id",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.trueAnomalyAtUTForManeuverNodesOrbitPatch",
@@ -3275,8 +3048,7 @@
     "category": "maneuver",
     "returnType": "double",
     "params": "int id, int patchIndex, double UT",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.UT",
@@ -3288,8 +3060,7 @@
     "category": "maneuver",
     "returnType": "double",
     "params": "int id",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.maneuverNodes.UTForTrueAnomalyForManeuverNodesOrbitPatch",
@@ -3301,8 +3072,7 @@
     "category": "maneuver",
     "returnType": "double",
     "params": "int id, int patchIndex, double trueAnomaly",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.mean.anomalisticPeriod",
@@ -3314,8 +3084,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.ApA",
@@ -3327,8 +3096,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.ApARange",
@@ -3340,8 +3108,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.argumentOfPeriapsis",
@@ -3353,8 +3120,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.eccentricity",
@@ -3366,8 +3132,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.eccentricityRange",
@@ -3379,8 +3144,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.inclination",
@@ -3392,8 +3156,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.inclinationRange",
@@ -3405,8 +3168,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.lan",
@@ -3418,8 +3180,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.nodalPeriod",
@@ -3431,8 +3192,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.nodalPrecession",
@@ -3444,8 +3204,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.PeA",
@@ -3457,8 +3216,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.PeARange",
@@ -3470,8 +3228,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.recurrence",
@@ -3483,8 +3240,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.siderealPeriod",
@@ -3496,8 +3252,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.sma",
@@ -3509,8 +3264,7 @@
     "category": "orbit",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.mean.smaRange",
@@ -3522,8 +3276,7 @@
     "category": "orbit",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "o.meanAnomaly",
@@ -3534,8 +3287,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.nextApsisType",
@@ -3546,8 +3298,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitalEnergy",
@@ -3558,8 +3309,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitalSpeed",
@@ -3570,8 +3320,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitalSpeedAt",
@@ -3583,8 +3332,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "double obt",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitalSpeedAtDistance",
@@ -3596,8 +3344,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "double distance",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitNormal",
@@ -3609,8 +3356,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitPatches",
@@ -3622,8 +3368,7 @@
     "category": "orbit",
     "returnType": "object",
     "formatter": "OrbitPatchList",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.orbitPercent",
@@ -3634,8 +3379,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.patchEndTransition",
@@ -3646,8 +3390,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.patchStartTransition",
@@ -3658,8 +3401,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.PeA",
@@ -3670,8 +3412,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.PeR",
@@ -3682,8 +3423,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.period",
@@ -3694,8 +3434,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.pos",
@@ -3707,8 +3446,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.radius",
@@ -3719,8 +3457,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.radiusAtTrueAnomaly",
@@ -3732,8 +3469,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "double trueAnomaly",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.referenceBody",
@@ -3744,8 +3480,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "string",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.relativePositionAtTrueAnomalyForOrbitPatch",
@@ -3758,8 +3493,7 @@
     "returnType": "Vector3d",
     "params": "int patchIndex, double trueAnomaly",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.relativePositionAtUTForOrbitPatch",
@@ -3772,8 +3506,7 @@
     "returnType": "Vector3d",
     "params": "int patchIndex, double UT",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.relativeVelocity",
@@ -3784,8 +3517,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.removeManeuverNode",
@@ -3797,8 +3529,7 @@
     "category": "maneuver",
     "returnType": "bool",
     "params": "int id",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.semiLatusRectum",
@@ -3809,8 +3540,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.semiMinorAxis",
@@ -3821,8 +3551,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.sma",
@@ -3833,8 +3562,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.StartUT",
@@ -3845,8 +3573,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeOfPeriapsisPassage",
@@ -3857,8 +3584,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeToAp",
@@ -3869,8 +3595,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeToNextApsis",
@@ -3881,8 +3606,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeToPe",
@@ -3893,8 +3617,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeToTransition1",
@@ -3905,8 +3628,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.timeToTransition2",
@@ -3917,8 +3639,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.trueAnomaly",
@@ -3929,8 +3650,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.trueAnomalyAtRadius",
@@ -3942,8 +3662,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "double radius",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.trueAnomalyAtUTForOrbitPatch",
@@ -3955,8 +3674,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "int patchIndex, double UT",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.updateManeuverNode",
@@ -3969,8 +3687,7 @@
     "returnType": "object",
     "params": "int id, float ut, float x, float y, float z",
     "formatter": "ManeuverNode",
-    "declaringClass": "MapViewDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "MapViewDataLinkHandler"
   },
   {
     "key": "o.UTForTrueAnomalyForOrbitPatch",
@@ -3982,8 +3699,7 @@
     "category": "orbit",
     "returnType": "double",
     "params": "int patchIndex, double trueAnomaly",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.UTsoi",
@@ -3994,8 +3710,7 @@
     "alwaysEvaluable": false,
     "category": "orbit",
     "returnType": "double",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "o.vel",
@@ -4007,8 +3722,7 @@
     "category": "orbit",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "OrbitDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "OrbitDataLinkHandler"
   },
   {
     "key": "p.paused",
@@ -4019,8 +3733,7 @@
     "alwaysEvaluable": true,
     "category": "system",
     "returnType": "int",
-    "declaringClass": "PausedDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/SystemHandlers.cs"
+    "declaringClass": "PausedDataLinkHandler"
   },
   {
     "key": "principia.active",
@@ -4032,8 +3745,7 @@
     "category": "principia",
     "returnType": "bool",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.analysis",
@@ -4045,8 +3757,7 @@
     "category": "principia",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.analysisProgress",
@@ -4058,8 +3769,7 @@
     "category": "principia",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.available",
@@ -4071,8 +3781,7 @@
     "category": "principia",
     "returnType": "bool",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.missionDuration",
@@ -4084,8 +3793,7 @@
     "category": "principia",
     "returnType": "double",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.plan.burn",
@@ -4098,8 +3806,7 @@
     "returnType": "object",
     "params": "int index",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.plan.burns",
@@ -4111,8 +3818,7 @@
     "category": "principia",
     "returnType": "object",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.plan.count",
@@ -4124,8 +3830,7 @@
     "category": "principia",
     "returnType": "int",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.plan.guidance",
@@ -4137,8 +3842,7 @@
     "category": "principia",
     "returnType": "bool",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "principia.version",
@@ -4150,8 +3854,7 @@
     "category": "principia",
     "returnType": "string",
     "requiresMod": "principia",
-    "declaringClass": "PrincipiaDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/PrincipiaDataLinkHandler.cs"
+    "declaringClass": "PrincipiaDataLinkHandler"
   },
   {
     "key": "r.resource",
@@ -4164,8 +3867,7 @@
     "returnType": "object",
     "params": "string resourceName",
     "formatter": "ResourceList",
-    "declaringClass": "ResourceDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "ResourceDataLinkHandler"
   },
   {
     "key": "r.resourceCurrent",
@@ -4178,8 +3880,7 @@
     "returnType": "object",
     "params": "string resourceName",
     "formatter": "ActiveResourceList",
-    "declaringClass": "ResourceDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "ResourceDataLinkHandler"
   },
   {
     "key": "r.resourceCurrentMax",
@@ -4192,8 +3893,19 @@
     "returnType": "object",
     "params": "string resourceName",
     "formatter": "MaxCurrentResourceList",
-    "declaringClass": "ResourceDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "ResourceDataLinkHandler"
+  },
+  {
+    "key": "r.resourceFor",
+    "description": "Live resources for a single part keyed by flightID. Returns { resourceName: { amount, maxAmount } }; empty object if the part has no resources or the flightID isn't found.",
+    "units": "UNITLESS",
+    "plotable": false,
+    "isAction": false,
+    "alwaysEvaluable": false,
+    "category": "resource",
+    "returnType": "object",
+    "params": "uint flightId",
+    "declaringClass": "ResourceDataLinkHandler"
   },
   {
     "key": "r.resourceMax",
@@ -4206,8 +3918,7 @@
     "returnType": "object",
     "params": "string resourceName",
     "formatter": "MaxResourceList",
-    "declaringClass": "ResourceDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "ResourceDataLinkHandler"
   },
   {
     "key": "r.resourceNameList",
@@ -4219,8 +3930,7 @@
     "category": "resource",
     "returnType": "string[]",
     "formatter": "StringArray",
-    "declaringClass": "ResourceDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "ResourceDataLinkHandler"
   },
   {
     "key": "rc.anyDeployed",
@@ -4232,8 +3942,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.arm",
@@ -4245,8 +3954,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.available",
@@ -4258,8 +3966,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.chutes",
@@ -4271,8 +3978,7 @@
     "category": "realchute",
     "returnType": "object",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.count",
@@ -4284,8 +3990,7 @@
     "category": "realchute",
     "returnType": "int",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.cut",
@@ -4297,8 +4002,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.deploy",
@@ -4310,8 +4014,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.disarm",
@@ -4323,8 +4026,7 @@
     "category": "realchute",
     "returnType": "bool",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "rc.safeState",
@@ -4336,8 +4038,7 @@
     "category": "realchute",
     "returnType": "string",
     "requiresMod": "realchute",
-    "declaringClass": "RealChuteDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/RealChuteDataLinkHandler.cs"
+    "declaringClass": "RealChuteDataLinkHandler"
   },
   {
     "key": "s.sensor",
@@ -4350,8 +4051,7 @@
     "returnType": "object",
     "params": "string sensorType",
     "formatter": "SensorModuleList",
-    "declaringClass": "SensorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "SensorDataLinkHandler"
   },
   {
     "key": "s.sensor.acc",
@@ -4363,8 +4063,7 @@
     "category": "sensor",
     "returnType": "object",
     "formatter": "SensorModuleList",
-    "declaringClass": "SensorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "SensorDataLinkHandler"
   },
   {
     "key": "s.sensor.grav",
@@ -4376,8 +4075,7 @@
     "category": "sensor",
     "returnType": "object",
     "formatter": "SensorModuleList",
-    "declaringClass": "SensorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "SensorDataLinkHandler"
   },
   {
     "key": "s.sensor.pres",
@@ -4389,8 +4087,7 @@
     "category": "sensor",
     "returnType": "object",
     "formatter": "SensorModuleList",
-    "declaringClass": "SensorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "SensorDataLinkHandler"
   },
   {
     "key": "s.sensor.temp",
@@ -4402,8 +4099,7 @@
     "category": "sensor",
     "returnType": "object",
     "formatter": "SensorModuleList",
-    "declaringClass": "SensorDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ResourceHandlers.cs"
+    "declaringClass": "SensorDataLinkHandler"
   },
   {
     "key": "sci.count",
@@ -4414,8 +4110,7 @@
     "alwaysEvaluable": false,
     "category": "science",
     "returnType": "int",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "sci.dataAmount",
@@ -4426,8 +4121,7 @@
     "alwaysEvaluable": false,
     "category": "science",
     "returnType": "double",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "sci.experiments",
@@ -4438,8 +4132,7 @@
     "alwaysEvaluable": false,
     "category": "science",
     "returnType": "object",
-    "declaringClass": "ScienceCareerDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ScienceCareerDataLinkHandler.cs"
+    "declaringClass": "ScienceCareerDataLinkHandler"
   },
   {
     "key": "t.currentRate",
@@ -4450,8 +4143,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "double",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.currentRateIndex",
@@ -4462,8 +4154,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "double",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.deltaTime",
@@ -4474,8 +4165,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "double",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.isPaused",
@@ -4486,8 +4176,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "bool",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.maxPhysicsRate",
@@ -4498,8 +4187,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "double",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.universalTime",
@@ -4510,8 +4198,7 @@
     "alwaysEvaluable": true,
     "category": "timewarp",
     "returnType": "double",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "t.warpMode",
@@ -4522,8 +4209,7 @@
     "alwaysEvaluable": false,
     "category": "timewarp",
     "returnType": "string",
-    "declaringClass": "TimeWarpDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TimeWarpDataLinkHandler"
   },
   {
     "key": "tar.clearTarget",
@@ -4534,8 +4220,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "int",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.distance",
@@ -4546,8 +4231,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.groundDistance",
@@ -4558,8 +4242,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.name",
@@ -4570,8 +4253,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "string",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.ApA",
@@ -4582,8 +4264,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.argumentOfPeriapsis",
@@ -4594,8 +4275,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.eccentricity",
@@ -4606,8 +4286,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.inclination",
@@ -4618,8 +4297,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.lan",
@@ -4630,8 +4308,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.maae",
@@ -4642,8 +4319,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.orbitingBody",
@@ -4654,8 +4330,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "string",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.orbitPatches",
@@ -4667,8 +4342,7 @@
     "category": "target",
     "returnType": "double",
     "formatter": "OrbitPatchList",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.PeA",
@@ -4679,8 +4353,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.period",
@@ -4691,8 +4364,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.relativeInclination",
@@ -4703,8 +4375,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.relativePositionAtTrueAnomalyForOrbitPatch",
@@ -4717,8 +4388,7 @@
     "returnType": "double",
     "params": "int orbitPatchIndex, float trueAnomaly",
     "formatter": "Vector3d",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.relativePositionAtUTForOrbitPatch",
@@ -4731,8 +4401,7 @@
     "returnType": "double",
     "params": "int orbitPatchIndex, double universalTime",
     "formatter": "Vector3d",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.relativeVelocity",
@@ -4743,8 +4412,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.sma",
@@ -4755,8 +4423,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.timeOfPeriapsisPassage",
@@ -4767,8 +4434,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.timeToAp",
@@ -4779,8 +4445,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.timeToPe",
@@ -4791,8 +4456,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.timeToTransition1",
@@ -4803,8 +4467,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.timeToTransition2",
@@ -4815,8 +4478,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.trueAnomaly",
@@ -4827,8 +4489,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.trueAnomalyAtUTForOrbitPatch",
@@ -4840,8 +4501,7 @@
     "category": "target",
     "returnType": "double",
     "params": "int orbitPatchIndex, float universalTime",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.UTForTrueAnomalyForOrbitPatch",
@@ -4853,8 +4513,7 @@
     "category": "target",
     "returnType": "double",
     "params": "int orbitPatchIndex, float trueAnomaly",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.o.velocity",
@@ -4865,8 +4524,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "double",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.setTargetBody",
@@ -4878,8 +4536,7 @@
     "category": "target",
     "returnType": "int",
     "params": "int bodyId",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.setTargetVessel",
@@ -4891,8 +4548,7 @@
     "category": "target",
     "returnType": "int",
     "params": "int vesselIndex",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "tar.type",
@@ -4903,8 +4559,7 @@
     "alwaysEvaluable": false,
     "category": "target",
     "returnType": "string",
-    "declaringClass": "TargetDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/NavigationHandlers.cs"
+    "declaringClass": "TargetDataLinkHandler"
   },
   {
     "key": "therm.anyEnginesOverheating",
@@ -4915,8 +4570,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "bool",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.heatShieldFlux",
@@ -4927,8 +4581,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.heatShieldTemp",
@@ -4939,8 +4592,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.heatShieldTempCelsius",
@@ -4951,8 +4603,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestEngineMaxTemp",
@@ -4963,8 +4614,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestEngineTemp",
@@ -4975,8 +4625,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestEngineTempRatio",
@@ -4987,8 +4636,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestPartMaxTemp",
@@ -4999,8 +4647,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestPartName",
@@ -5011,8 +4658,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "string",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestPartTemp",
@@ -5023,8 +4669,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestPartTempKelvin",
@@ -5035,8 +4680,7 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "therm.hottestPartTempRatio",
@@ -5047,8 +4691,19 @@
     "alwaysEvaluable": false,
     "category": "thermal",
     "returnType": "double",
-    "declaringClass": "ThermalDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/ThermalDataLinkHandler.cs"
+    "declaringClass": "ThermalDataLinkHandler"
+  },
+  {
+    "key": "therm.part",
+    "description": "Thermal state for a single part keyed by flightID. Returns { temperature, maxTemperature, temperatureK, maxTemperatureK }; null if the flightID isn't found. Core part temperature only — skin temperature is not exposed here.",
+    "units": "UNITLESS",
+    "plotable": false,
+    "isAction": false,
+    "alwaysEvaluable": false,
+    "category": "thermal",
+    "returnType": "object",
+    "params": "uint flightId",
+    "declaringClass": "ThermalDataLinkHandler"
   },
   {
     "key": "v.abortValue",
@@ -5059,8 +4714,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.acceleration",
@@ -5071,8 +4725,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.accelerationx",
@@ -5083,8 +4736,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.accelerationy",
@@ -5095,8 +4747,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.accelerationz",
@@ -5107,8 +4758,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.ag10Value",
@@ -5119,8 +4769,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag1Value",
@@ -5131,8 +4780,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag2Value",
@@ -5143,8 +4791,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag3Value",
@@ -5155,8 +4802,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag4Value",
@@ -5167,8 +4813,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag5Value",
@@ -5179,8 +4824,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag6Value",
@@ -5191,8 +4835,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag7Value",
@@ -5203,8 +4846,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag8Value",
@@ -5215,8 +4857,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.ag9Value",
@@ -5227,8 +4868,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.altitude",
@@ -5239,8 +4879,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angleToPrograde",
@@ -5251,8 +4890,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularMomentum",
@@ -5263,8 +4901,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularMomentumx",
@@ -5275,8 +4912,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularMomentumy",
@@ -5287,8 +4923,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularMomentumz",
@@ -5299,8 +4934,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularVelocity",
@@ -5311,8 +4945,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularVelocityx",
@@ -5323,8 +4956,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularVelocityy",
@@ -5335,8 +4967,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.angularVelocityz",
@@ -5347,8 +4978,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.atmosphericDensity",
@@ -5359,8 +4989,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.atmosphericPressure",
@@ -5371,8 +5000,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.atmosphericPressurePa",
@@ -5383,8 +5011,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.atmosphericTemperature",
@@ -5395,8 +5022,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.biome",
@@ -5407,8 +5033,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.biomeLocalized",
@@ -5419,8 +5044,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.body",
@@ -5431,8 +5055,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.brakeValue",
@@ -5443,8 +5066,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.CoM",
@@ -5456,8 +5078,7 @@
     "category": "vessel",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.crew",
@@ -5469,8 +5090,7 @@
     "category": "vessel",
     "returnType": "string[]",
     "formatter": "StringArray",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.crewCapacity",
@@ -5481,8 +5101,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "int",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.crewCount",
@@ -5493,8 +5112,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "int",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.currentStage",
@@ -5505,8 +5123,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "int",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.directSunlight",
@@ -5517,8 +5134,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.distanceToSun",
@@ -5529,8 +5145,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.dynamicPressure",
@@ -5541,8 +5156,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.dynamicPressurekPa",
@@ -5553,8 +5167,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.externalTemperature",
@@ -5565,8 +5178,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.gearValue",
@@ -5577,8 +5189,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.geeForce",
@@ -5589,8 +5200,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.geeForceImmediate",
@@ -5601,8 +5211,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.heightFromSurface",
@@ -5613,8 +5222,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.heightFromTerrain",
@@ -5625,8 +5233,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.indicatedAirSpeed",
@@ -5637,8 +5244,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.isActiveVessel",
@@ -5649,8 +5255,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.isCommandable",
@@ -5661,8 +5266,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.isControllable",
@@ -5673,8 +5277,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.isEVA",
@@ -5685,8 +5288,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.landed",
@@ -5697,8 +5299,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.landedAt",
@@ -5709,8 +5310,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.landedOrSplashed",
@@ -5721,8 +5321,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.lat",
@@ -5733,8 +5332,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.launchTime",
@@ -5745,8 +5343,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.lightValue",
@@ -5757,8 +5354,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.loaded",
@@ -5769,8 +5365,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.long",
@@ -5781,8 +5376,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.mach",
@@ -5793,8 +5387,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.mass",
@@ -5805,8 +5398,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.missionTime",
@@ -5817,8 +5409,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.missionTimeString",
@@ -5829,8 +5420,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.momentOfInertia",
@@ -5842,8 +5432,7 @@
     "category": "vessel",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.name",
@@ -5854,8 +5443,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.obtSpeed",
@@ -5866,8 +5454,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.orbitalVelocity",
@@ -5878,8 +5465,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.orbitalVelocityx",
@@ -5890,8 +5476,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.orbitalVelocityy",
@@ -5902,8 +5487,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.orbitalVelocityz",
@@ -5914,8 +5498,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.packed",
@@ -5926,8 +5509,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.perturbation",
@@ -5938,8 +5520,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.perturbationx",
@@ -5950,8 +5531,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.perturbationy",
@@ -5962,8 +5542,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.perturbationz",
@@ -5974,8 +5553,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.pqsAltitude",
@@ -5986,8 +5564,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.precisionControlValue",
@@ -5998,8 +5575,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.rcsValue",
@@ -6010,8 +5586,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.sasValue",
@@ -6022,8 +5597,7 @@
     "alwaysEvaluable": false,
     "category": "flight",
     "returnType": "bool",
-    "declaringClass": "FlightDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlightDataLinkHandler"
   },
   {
     "key": "v.setAttitude",
@@ -6035,8 +5609,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float pitch, float yaw, float roll",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setFbW",
@@ -6048,8 +5621,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "int state",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setPitch",
@@ -6061,8 +5633,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float pitch",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setPitchYawRollXYZ",
@@ -6074,8 +5645,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float pitch, float yaw, float roll, float x, float y, float z",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setRoll",
@@ -6087,8 +5657,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float roll",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setTranslation",
@@ -6100,8 +5669,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float x, float y, float z",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.setYaw",
@@ -6113,8 +5681,7 @@
     "category": "fbw",
     "returnType": "int",
     "params": "float yaw",
-    "declaringClass": "FlyByWireDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/FlightControlHandlers.cs"
+    "declaringClass": "FlyByWireDataLinkHandler"
   },
   {
     "key": "v.situation",
@@ -6125,8 +5692,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.situationString",
@@ -6137,8 +5703,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.solarFlux",
@@ -6149,8 +5714,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.specificAcceleration",
@@ -6161,8 +5725,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.speed",
@@ -6173,8 +5736,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.speedOfSound",
@@ -6185,8 +5747,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.splashed",
@@ -6197,8 +5758,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "bool",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.srfSpeed",
@@ -6209,8 +5769,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.staticPressure",
@@ -6221,8 +5780,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.staticPressurekPa",
@@ -6233,8 +5791,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.surfaceSpeed",
@@ -6245,8 +5802,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.surfaceVelocity",
@@ -6257,8 +5813,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.surfaceVelocityx",
@@ -6269,8 +5824,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.surfaceVelocityy",
@@ -6281,8 +5835,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.surfaceVelocityz",
@@ -6293,8 +5846,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.terrainHeight",
@@ -6305,8 +5857,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.terrainNormal",
@@ -6318,8 +5869,29 @@
     "category": "vessel",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
+  },
+  {
+    "key": "v.topology",
+    "description": "Active vessel topology: rootFlightId + per-part flightId, persistentId, parentFlightId, name, title, manufacturer, category, inverseStage, crewCapacity, maxTemp, crashTolerance, dryMass, orgPos[x,y,z], bounds.size{x,y,z}, modules[]. Cached and event-invalidated — subscribe to v.topologySeq to detect changes rather than streaming this key.",
+    "units": "UNITLESS",
+    "plotable": false,
+    "isAction": false,
+    "alwaysEvaluable": false,
+    "category": "vessel",
+    "returnType": "object",
+    "declaringClass": "PartsTopologyDataLinkHandler"
+  },
+  {
+    "key": "v.topologySeq",
+    "description": "Monotonic counter bumped whenever vessel topology changes. Subscribe to this and refetch v.topology only when it ticks.",
+    "units": "UNITLESS",
+    "plotable": true,
+    "isAction": false,
+    "alwaysEvaluable": true,
+    "category": "vessel",
+    "returnType": "int",
+    "declaringClass": "PartsTopologyDataLinkHandler"
   },
   {
     "key": "v.upAxis",
@@ -6331,8 +5903,7 @@
     "category": "vessel",
     "returnType": "Vector3d",
     "formatter": "Vector3d",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.verticalSpeed",
@@ -6343,8 +5914,7 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "double",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   },
   {
     "key": "v.vesselType",
@@ -6355,7 +5925,6 @@
     "alwaysEvaluable": false,
     "category": "vessel",
     "returnType": "string",
-    "declaringClass": "VesselDataLinkHandler",
-    "sourceFile": "/home/sol/repos/personal/Telemachus-1/Telemachus/src/VesselDataHandlers.cs"
+    "declaringClass": "VesselDataLinkHandler"
   }
 ]

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -11518,6 +11518,32 @@ paths:
                   v.packed:
                     type: boolean
       x-plotable: true
+  "/api/v.partState":
+    get:
+      summary: "Live deployable / behavioural state for a single part keyed by flightID. Returns { seq, modules: [{ type, state, ...extras }] }. Cached server-side and invalidated on staging, action-group events, vessel modifications, part death / undock / couple, and PAW dismiss; plus a 10s backstop covering player right-click interactions that don't fire a global event. Consumers subscribe and dedup on the seq field rather than re-processing the modules array on every push."
+      operationId: v.partState
+      tags:
+        - vessel
+      parameters:
+        - name: flightId
+          in: query
+          required: true
+          description: uint parameter (passed via bracket notation)
+          schema:
+            type: string
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  v.partState:
+                    type: object
   "/api/v.perturbation":
     get:
       summary: Orbital Perturbation Magnitude

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8330,7 +8330,7 @@ paths:
                     type: object
   "/api/r.resourceFor":
     get:
-      summary: "Live resources for a single part keyed by flightID. Returns { resourceName: { amount, maxAmount } }; empty object if the part has no resources or the flightID isn't found."
+      summary: "Live resources for a single part keyed by flightID. Returns { resourceName: { amount, maxAmount, flow?, nominalFlow? } }. amount / maxAmount cover storage; flow is signed units/sec (positive = producing, negative = consuming) summed across the part's modules; nominalFlow is the 100%-efficiency cap. Both are omitted when the part contributes none, when no module supports a nominal (e.g. engines), or when nominal equals flow. Rows are emitted for resources the part contributes flow to even when storage is zero (RTGs, solar panels). Empty object when the flightID isn't found."
       operationId: r.resourceFor
       tags:
         - resource
@@ -12330,7 +12330,7 @@ paths:
                       type: number
   "/api/v.topology":
     get:
-      summary: "Active vessel topology: rootFlightId + per-part flightId, persistentId, parentFlightId, name, title, manufacturer, category, inverseStage, crewCapacity, maxTemp, crashTolerance, dryMass, orgPos[x,y,z], bounds.size{x,y,z}, modules[]. Cached and event-invalidated — subscribe to v.topologySeq to detect changes rather than streaming this key."
+      summary: "Active vessel topology: rootFlightId + per-part flightId, persistentId, parentFlightId, fuelLineTarget (flightId of the receiving tank for fuel-line parts, null otherwise), name, title, manufacturer, category, inverseStage, crewCapacity, maxTemp, crashTolerance, dryMass, orgPos[x,y,z], up[x,y,z] (part-local up in vessel frame), bounds.size{x,y,z}, bounds.center{x,y,z} (mesh-center offset from orgPos in vessel-local frame — already rotated by orgRot; add it to orgPos to get the mesh centre in assembly space), modules[]. Cached and event-invalidated — subscribe to v.topologySeq to detect changes rather than streaming this key."
       operationId: v.topology
       tags:
         - vessel

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8328,6 +8328,32 @@ paths:
                 properties:
                   r.resourceCurrentMax:
                     type: object
+  "/api/r.resourceFor":
+    get:
+      summary: "Live resources for a single part keyed by flightID. Returns { resourceName: { amount, maxAmount } }; empty object if the part has no resources or the flightID isn't found."
+      operationId: r.resourceFor
+      tags:
+        - resource
+      parameters:
+        - name: flightId
+          in: query
+          required: true
+          description: uint parameter (passed via bracket notation)
+          schema:
+            type: string
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  r.resourceFor:
+                    type: object
   "/api/r.resourceMax":
     get:
       summary: Max Resource Information
@@ -9892,6 +9918,32 @@ paths:
                   therm.hottestPartTempRatio:
                     type: number
       x-plotable: true
+  "/api/therm.part":
+    get:
+      summary: "Thermal state for a single part keyed by flightID. Returns { temperature, maxTemperature, temperatureK, maxTemperatureK }; null if the flightID isn't found. Core part temperature only — skin temperature is not exposed here."
+      operationId: therm.part
+      tags:
+        - thermal
+      parameters:
+        - name: flightId
+          in: query
+          required: true
+          description: uint parameter (passed via bracket notation)
+          schema:
+            type: string
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  therm.part:
+                    type: object
   "/api/v.abortValue":
     get:
       summary: Query abort value
@@ -12250,6 +12302,47 @@ paths:
                     type: array
                     items:
                       type: number
+  "/api/v.topology":
+    get:
+      summary: "Active vessel topology: rootFlightId + per-part flightId, persistentId, parentFlightId, name, title, manufacturer, category, inverseStage, crewCapacity, maxTemp, crashTolerance, dryMass, orgPos[x,y,z], bounds.size{x,y,z}, modules[]. Cached and event-invalidated — subscribe to v.topologySeq to detect changes rather than streaming this key."
+      operationId: v.topology
+      tags:
+        - vessel
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  v.topology:
+                    type: object
+  "/api/v.topologySeq":
+    get:
+      summary: Monotonic counter bumped whenever vessel topology changes. Subscribe to this and refetch v.topology only when it ticks.
+      operationId: v.topologySeq
+      tags:
+        - vessel
+      parameters:
+        -           $ref: "#/components/parameters/ScaleParam"
+        -           $ref: "#/components/parameters/PrecisionParam"
+        -           $ref: "#/components/parameters/IntParam"
+      responses:
+        200:
+          description: Successful response
+          content:
+            "application/json":
+              schema:
+                type: object
+                properties:
+                  v.topologySeq:
+                    type: integer
+      x-plotable: true
   "/api/v.upAxis":
     get:
       summary: Local Up Axis

--- a/tools/generate-openapi.ts
+++ b/tools/generate-openapi.ts
@@ -481,7 +481,9 @@ const outPath = resolve(outDir, "openapi.yaml");
 writeFileSync(outPath, yaml + "\n");
 console.log(`Written ${outPath}`);
 
-// Also write the merged JSON for easy consumption
+// Also write the merged JSON for easy consumption.
+// `sourceFile` is omitted here — kept on the in-memory entries for tooling use, off the committed artifact.
 const mergedJsonPath = resolve(outDir, "api-schema.json");
-writeFileSync(mergedJsonPath, JSON.stringify(all, null, 2) + "\n");
+const sanitized = all.map(({ sourceFile: _sourceFile, ...rest }) => rest);
+writeFileSync(mergedJsonPath, JSON.stringify(sanitized, null, 2) + "\n");
 console.log(`Written ${mergedJsonPath}`);


### PR DESCRIPTION
## Summary

A native parts-API surface for clients that need to reason about vessel structure, built around a structural snapshot plus targeted per-part live lookups rather than one firehose stream:

| Key                       | Returns                                                                                                                                                                                                                                                                                                                                        |
| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `v.topology`              | Active vessel structure: `{ topologySeq, rootFlightId, parts: [...] }` with per-part `flightId / persistentId / parentFlightId / name / title / manufacturer / category / inverseStage / crewCapacity / maxTemp / crashTolerance / dryMass / orgPos[x,y,z] / up[x,y,z] / bounds.size{x,y,z} / bounds.center{x,y,z} / fuelLineTarget / modules[]` |
| `v.topologySeq`           | Monotonic int, bumps on every structural change                                                                                                                                                                                                                                                                                                |
| `r.resourceFor[flightId]` | Live `{ resourceName: { amount, maxAmount, flow?, nominalFlow? }, … }` for a single part; `flow` + `nominalFlow` appear when a module on the part contributes to that resource                                                                                                                                                                 |
| `therm.part[flightId]`    | Live `{ temperature, maxTemperature, temperatureK, maxTemperatureK }` for a single part; `temperature`/`maxTemperature` in °C, the `K` variants in Kelvin (core temp only, no skin temp)                                                                                                                                                       |
| `v.partState[flightId]`   | Live `{ seq, modules: [{ type, state, ...extras }] }`: semantic deployable / activation state per supported module                                                                                                                                                                                                                             |

`v.topology` is cached and event-invalidated; consumers subscribe to `v.topologySeq` and refetch the topology only when the seq ticks. `v.partState` carries its own embedded vessel-level `seq` for consumer-side dedup. Resource and thermal lookups are stateless per-call walks of `vessel.parts`.

## Why this shape

Position uses `Part.orgPos`, not the live transform, so topology represents the vessel as assembled rather than wobbling with simulation state. Bounds are computed from the prefab (`PartGeometryUtil.MergeBounds`) and cached per part name, which avoids world-AABB inflation from rotation and joint flex. Trade-off: mid-extend deployables don't bump the bounds.

Resources and thermals are separate per-part keys rather than embedded in topology so topology can be cached across the quiet stretches between staging events. Modules in `v.topology` are a raw name list and staging is per-part `inverseStage`, both trivial to group client-side.

`v.partState` maps supported modules onto a fixed state vocabulary so consumers branch on `type` strings rather than walking module class hierarchies. Mods that subclass a supported base pick up the same mapping automatically.

`r.resourceFor` flow is signed (producers positive, consumers negative) and per-module. `nominalFlow` is omitted when it can't be computed cheaply rather than guessed. Each module dispatch is wrapped in a try/catch so one misbehaving module doesn't affect the rest of the response.

## Invalidation

**Topology** (`v.topologySeq` bumps on):

- `onVesselChange` (Tracking Station "Fly" / `[` / `]` between existing vessels)
- `onPartCouple` / `onPartUndock` / `onPartDie`
- `onVesselCreate` / `onVesselDestroy`
- `onFlightReady`

`onVesselWasModified` is deliberately **not** subscribed; the topology payload is built from prefab bounds, as-assembled `orgPos`, parent links and the static module-name list, none of which change with deployable state, ignition, arming, or crew transfer. Subscribing to it bumped the seq dozens of times per flight without the payload changing.

**Part state** (`v.partState[...].seq` bumps on):

- `onStageActivate`
- `onVesselWasModified`
- `onPartCouple` / `onPartUndock` / `onPartDie`
- `onPartActionUIDismiss` (right-click menu closed; player likely just acted)

Both caches rebuild lazily: handlers just bump the seq and drop the cache; the next read does the walk. `v.partState` adds a 10s backstop that force-invalidates if no real event has fired, covering player toggles (G key, custom action groups) that don't surface as global GameEvents on this KSP version. Worst-case staleness for non-event transitions is therefore ~10s.

<details>
<summary><code>r.resourceFor</code> module-flow dispatch</summary>

| Module                                                                                                  | Current rate (`flow`)                                   | Nominal cap (`nominalFlow`)   | Sign                                                          |
| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- | ----------------------------- | ------------------------------------------------------------- |
| `ModuleDeployableSolarPanel`                                                                            | `flowRate`                                              | `chargeRate × efficiencyMult` | + (producer)                                                  |
| `ModuleGenerator` (RTGs / fuel cells)                                                                   | `output.rate × efficiency` / `−input.rate × efficiency` | `output.rate` / `−input.rate` | + outputs / − inputs                                          |
| `ModuleResourceConverter` (covers ISRU + drills + fuel cells via `ModuleResourceHarvester` inheritance) | `Ratio × lastTimeFactor`                                | `Ratio`                       | + outputs / − inputs                                          |
| `ModuleEngines` (covers `ModuleEnginesFX` via inheritance)                                              | `−prop.currentRequirement / fixedDeltaTime`             | omitted                       | − (consumer)                                                  |
| `ModuleAlternator`                                                                                      | `outputRate`                                            | omitted                       | + (producer, EC only)                                         |
| `ModuleDataTransmitter` (antenna, transmitting only)                                                    | `−packetResourceCost / packetInterval`                  | same                          | − (consumer, EC)                                              |
| `ModuleCommand` (probe core / crewed pod)                                                               | `−resHandler.inputResources[].rate`                     | same                          | − (consumer)                                                  |
| `ModuleReactionWheel` (when Active)                                                                     | `−resHandler.inputResources[].rate`                     | same                          | − (consumer; approximation, KSP doesn't expose live draw)     |
| `ModuleLight` (when on)                                                                                 | `−resourceAmount`                                       | same                          | − (consumer, EC)                                              |
| `TelemachusPowerDrain` (this mod's data-link antenna)                                                   | `−powerConsumption`                                     | omitted                       | − (consumer, EC)                                              |

Mod modules that subclass any of the above pick up the same dispatch through `is` pattern matching, so e.g. Near Future Solar's panels flow without further work.

</details>

<details>
<summary><code>v.partState</code> supported modules</summary>

| `type`        | Source module                                               | State vocabulary used                                                       |
| ------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------- |
| `solarPanel`  | `ModuleDeployableSolarPanel`                                | extended / retracted / deploying / retracting / broken (+ `tracking: bool`) |
| `radiator`    | `ModuleDeployableRadiator`                                  | extended / retracted / deploying / retracting / broken                      |
| `antenna`     | `ModuleDeployableAntenna`                                   | extended / retracted / deploying / retracting / broken                      |
| `parachute`   | `ModuleParachute`                                           | stowed / armed / deploying / extended / broken                              |
| `engine`      | `ModuleEngines` (incl. `ModuleEnginesFX`)                   | active / inactive (+ `flameout: true` when out of fuel)                     |
| `drill`       | `ModuleResourceHarvester` (via `BaseConverter.IsActivated`) | active / inactive                                                           |
| `cargoBay`    | `ModuleCargoBay` paired with sibling `ModuleAnimateGeneric` | extended / retracted / deploying / retracting                               |
| `landingGear` | `ModuleWheels.ModuleWheelDeployment` (`stateString`)        | extended / retracted / deploying / retracting / broken                      |

Modules that don't match a supported type are skipped (no raw passthrough; that's what `v.topology.parts[].modules` is for). Unrecognised FSM states map to `"unknown"` rather than guessing. Decouplers were dropped from the v1 list: a one-shot binary the topology seq already covers via `onPartUndock`.

</details>

## Fixes made on this branch

Two live-flight bugs caught and fixed before this PR:

- **Engine flow was units-per-frame, not units-per-sec.** `Propellant.currentRequirement` is set per `FixedUpdate`; emitting it directly read ~56× too low against the observed tank drain. Fixed to divide by `TimeWarp.fixedDeltaTime` with a `dt > 0` guard.
- **Alternator emitted ghost EC after flameout.** KSP leaves `outputRate` at its last non-zero value once an engine stops. The alternator dispatch now gates on a live sibling-engine check (`EngineIgnited && !flameout`), so the row drops when thrust stops (commit `00d85d8`).

## Validation

- `dotnet build` clean (4 pre-existing warnings, 0 errors).
- README sections added for `v.topology` (full part shape including `up` / `bounds.center` / `fuelLineTarget`), `v.partState`, and the `r.*` / `therm.*` tables.
- OpenAPI regenerated — all five keys present in `docs/openapi.yaml` + `docs/api-schema.json`, including the full `v.topology` shape with `up` / `bounds.center` / `fuelLineTarget` and the `r.resourceFor` `flow` / `nominalFlow` fields.
- `tools/generate-openapi.ts` now strips the `sourceFile` field from the committed `docs/api-schema.json`; it carried a machine-local absolute path and produced large per-rebuild diffs.

Exercised live against running KSP: topology seq held flat through action-group events and only bumped on genuine structure changes (dock, stage decouple); `r.resourceFor` sign convention correct across solar, RTG, engine, command pod, alternator, and antenna cases with engine units confirmed against catalog figures; `therm.part` tracked a full ascent/descent temperature arc; `v.partState` transitions confirmed for `solarPanel`, `engine`, and `parachute` including the `tracking` extra and PAW-dismiss seq bumps; fuel-line `fuelLineTarget` round-trips correctly.